### PR TITLE
fix(BaseCollection): 修复 BaseCollection 在处理分页逻辑上的错误

### DIFF
--- a/src/models/BaseCollection.ts
+++ b/src/models/BaseCollection.ts
@@ -36,7 +36,11 @@ export default class BaseCollection<T> extends Model {
     return Observable.create((observer: Observer<Observable<T[]>>) => {
       let destSignal: Observable<T[]>
       if (this.hasPage(page)) {
-        destSignal = this.get(page)
+        if (page === 1) {
+          destSignal = this._singals.get(page)
+        } else {
+          destSignal = this.get(page)
+        }
       } else {
         this._data.set(page, data)
         if (!this._pages.length) {
@@ -83,11 +87,15 @@ export default class BaseCollection<T> extends Model {
   get(page?: number): Observable<T[]> {
     if (page) {
       if (this.hasPage(page)) {
-        const getSignal = this._singals.get(page)
-        if (getSignal) {
-          return getSignal
+        if (page !== 1) {
+          const getSignal = this._singals.get(page)
+          if (getSignal) {
+            return getSignal
+          } else {
+            return null
+          }
         } else {
-          return null
+          return this._get<T[]>(this._dbIndex)
         }
       }
     } else {

--- a/test/unit/storage/BaseCollectionSpec.ts
+++ b/test/unit/storage/BaseCollectionSpec.ts
@@ -109,12 +109,18 @@ export default describe('models/BaseCollection test: ', () => {
     collection.addPage(1, page1)
       .subscribe()
 
-    collection.get(1)
+    collection.addPage(1, page1)
       .subscribeOn(Scheduler.async, global.timeout1)
-      .subscribe(r => {
-        expect(r.length).to.equal(page1.length)
-        done()
-      })
+      .subscribe()
+
+    setTimeout(() => {
+      collection.get(1)
+        .subscribe(r => {
+          expect(r.length).to.equal(page1.length)
+          done()
+        })
+    }, global.timeout2)
+
   })
 
   it('get page2 should ok', done => {


### PR DESCRIPTION
如果直接缓存 this._saveCollection 的流就会导致除了第一次以外的流不处理数据更新，也会导致重复存储同一个 collection。所以需要对 page = 1 的情况做特殊处理。