### PR TITLE
hotfix: 修复 SocketClient 处理 new 事件的逻辑

### DIFF
--- a/mock/socket.ts
+++ b/mock/socket.ts
@@ -33,6 +33,22 @@ export class SocketMock {
   }
 
   emit(
+    method: 'change' | 'destroy' | 'refresh' | 'remove',
+    objectType: SocketEventType,
+    objectId: string,
+    patch?: any,
+    delay?: number
+  ): void
+
+  emit(
+    method: 'new',
+    objectType: SocketEventType,
+    objectId: '',
+    patch?: any,
+    delay?: number
+  ): void
+
+  emit(
     method: 'change' | 'destroy' | 'new' | 'refresh' | 'remove',
     objectType: SocketEventType,
     objectId: string,

--- a/src/sockets/EventMaps.ts
+++ b/src/sockets/EventMaps.ts
@@ -80,7 +80,7 @@ function handler(socketMessage: MessageResult) {
   const _method = methodMap[method]
   const model = typeMap[type]
   if (
-    (method !== 'destroy' && model && typeof data === 'object' && id) ||
+    (method !== 'destroy' && model && typeof data === 'object' && (!!id || method === 'new')) ||
     (method === 'destroy' && model && id && _method)
   ) {
     switch (method) {
@@ -91,7 +91,7 @@ function handler(socketMessage: MessageResult) {
           }))
             .mergeAll()
             .skip(data.length - 1)
-        }else {
+        } else {
           return model[_method](data)
         }
       case 'change':

--- a/src/sockets/SocketClient.ts
+++ b/src/sockets/SocketClient.ts
@@ -44,9 +44,9 @@ export class SocketClient {
 
   initClient(client: Consumer): void {
     this._client = client
-    this._client._join = this._join
-    this._client.onmessage = this._onmessage
-    this._client.onopen = this._onopen
+    this._client._join = this._join.bind(this)
+    this._client.onmessage = this._onmessage.bind(this)
+    this._client.onopen = this._onopen.bind(this)
     this._client['getToken'] = () => {
       if (this._me) {
         return this._me.snapperToken
@@ -116,7 +116,7 @@ export class SocketClient {
   private _onmessage(event: RequestEvent) {
     if (this._isDebug) {
       // 避免被插件清除掉
-      ctx['console']['log'](event)
+      ctx['console']['log'](JSON.stringify(event, null, 2))
     }
     const subscription = socketHandler(event)
       .subscribe(null, err => ctx['console']['error'](err), () => {

--- a/test/unit/socket/activity.ts
+++ b/test/unit/socket/activity.ts
@@ -75,7 +75,7 @@ export default describe('activity socket test', () => {
 
     httpBackend.flush()
 
-    Socket.emit('new', 'activity', _boundToObjectId, mockActivity)
+    Socket.emit('new', 'activity', '', mockActivity)
   })
 
   it('new comment should ok', done => {
@@ -131,6 +131,6 @@ export default describe('activity socket test', () => {
 
     httpBackend.flush()
 
-    Socket.emit('new', 'activity', _boundToObjectId, mockComment)
+    Socket.emit('new', 'activity', '', mockComment)
   })
 })

--- a/test/unit/socket/event.ts
+++ b/test/unit/socket/event.ts
@@ -172,7 +172,7 @@ export default describe('socket event test: ', () => {
           done()
         })
 
-      Socket.emit('new', 'event', 'mockevent', mockEvent)
+      Socket.emit('new', 'event', '', mockEvent)
 
       httpBackend.flush()
     })
@@ -189,7 +189,7 @@ export default describe('socket event test: ', () => {
           done()
         })
 
-      Socket.emit('new', 'event', 'mockrecurrence', mockEvent)
+      Socket.emit('new', 'event', '', mockEvent)
 
       httpBackend.flush()
     })
@@ -234,7 +234,7 @@ export default describe('socket event test: ', () => {
             done()
           })
 
-        Socket.emit('new', 'event', 'mock_new_event', mockNew)
+        Socket.emit('new', 'event', '', mockNew)
         Socket.emit('change', 'event', mockReapeat._id, mockReapeat)
       }, global.timeout2)
 
@@ -350,7 +350,7 @@ export default describe('socket event test: ', () => {
           done()
         })
 
-      Socket.emit('new', 'event', 'mockevent', mockEvent)
+      Socket.emit('new', 'event', '', mockEvent)
 
       httpBackend.flush()
     })
@@ -367,7 +367,7 @@ export default describe('socket event test: ', () => {
           done()
         })
 
-      Socket.emit('new', 'event', 'mockrecurrence', mockEvent)
+      Socket.emit('new', 'event', '', mockEvent)
 
       httpBackend.flush()
     })
@@ -412,7 +412,7 @@ export default describe('socket event test: ', () => {
             done()
           })
 
-        Socket.emit('new', 'event', 'mock_new_event', mockNew)
+        Socket.emit('new', 'event', '', mockNew)
         Socket.emit('change', 'event', mockReapeat._id, mockReapeat)
       }, global.timeout2)
 

--- a/test/unit/socket/feedback.ts
+++ b/test/unit/socket/feedback.ts
@@ -42,7 +42,7 @@ export default describe('feedback socket: ', () => {
         done()
       })
 
-    Socket.emit('new', 'feedback', mockFeedback._id, mockFeedback)
+    Socket.emit('new', 'feedback', '', mockFeedback)
 
     httpBackend.flush()
   })

--- a/test/unit/socket/message.ts
+++ b/test/unit/socket/message.ts
@@ -73,7 +73,7 @@ export default describe('socket message test: ', () => {
         done()
       })
 
-    Socket.emit('new', 'message', mockMessages[0]._id, mockMessage)
+    Socket.emit('new', 'message', '', mockMessage)
 
     httpBackend.flush()
   })

--- a/test/unit/socket/project.ts
+++ b/test/unit/socket/project.ts
@@ -122,7 +122,7 @@ export default describe('project socket test', () => {
         done()
       })
 
-    Socket.emit('new', 'homeActivity', projectId, homeActivity)
+    Socket.emit('new', 'homeActivity', '', homeActivity)
 
     httpBackend.flush()
   })

--- a/test/unit/socket/task.ts
+++ b/test/unit/socket/task.ts
@@ -112,7 +112,7 @@ export default describe('socket task test: ', () => {
 
       httpBackend.flush()
 
-      Socket.emit('new', 'task', 'mocktaskid', {
+      Socket.emit('new', 'task', '', {
         _id: 'mocktaskid',
         content: 'mock task content',
         dueDate: moment(dueDate).add(1, 'hour').toISOString() ,
@@ -173,7 +173,7 @@ export default describe('socket task test: ', () => {
 
       httpBackend.flush()
 
-      Socket.emit('new', 'task', 'mocktaskid', {
+      Socket.emit('new', 'task', '', {
         _id: 'mocktaskid',
         content: 'mock task content',
         dueDate: null,


### PR DESCRIPTION
SocketClient 在处理 snapper-consumer 回调的时候没有 bind this