### PR TITLE
fix(tools/test): fs.watch 的 recursive 模式在 linux 下不可用，使用 node-watch 模块…

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "google-closure-compiler-js": "^20161024.0.0",
     "jsonrpc-lite": "^1.2.1",
     "moment": "^2.16.0",
+    "node-watch": "^0.4.1",
     "nyc": "^10.0.0",
     "rollup": "^0.36.1",
     "rollup-plugin-alias": "^1.2.0",

--- a/tools/tasks/test.ts
+++ b/tools/tasks/test.ts
@@ -1,9 +1,9 @@
 'use strict'
 import * as path from 'path'
-import * as fs from 'fs'
 import * as Tman from 'tman'
 
-const cache: {[index: string]: any} = {}
+const watchFile = require('node-watch')
+
 const testDir = path.join(process.cwd(), 'spec-js/test/unit')
 
 for (let key of ['describe', 'suite', 'test', 'it', 'before', 'after', 'beforeEach', 'afterEach']) {
@@ -34,9 +34,7 @@ function excuteTest() {
   }, 200)
 }
 
-fs.watch(path.join(process.cwd(), 'spec-js'), <any>{
-  recursive: true
-}, event => {
+watchFile(path.join(process.cwd(), 'spec-js'), () => {
   excuteTest()
 })
 


### PR DESCRIPTION
…代替这个功能