### PR TITLE
TPLN-440: 一致取消将被用于 URL path 字段的值前面的斜杠（“/”）

### DIFF
--- a/src/SDKFetch.ts
+++ b/src/SDKFetch.ts
@@ -38,6 +38,6 @@ export class SDKFetch extends Fetch {
   }
 
   getUserMe() {
-    return this.get<UserMe>('/users/me')
+    return this.get<UserMe>('users/me')
   }
 }

--- a/src/apis/event/get.ts
+++ b/src/apis/event/get.ts
@@ -11,7 +11,7 @@ export function getEventFetch(
   eventId: EventId,
   query?: any
 ): Observable<EventSchema[]> {
-  return this.get<EventSchema[]>(`/events/${eventId}`, query)
+  return this.get<EventSchema[]>(`events/${eventId}`, query)
 }
 
 SDKFetch.prototype.getEvent = getEventFetch

--- a/src/apis/my/count.ts
+++ b/src/apis/my/count.ts
@@ -14,7 +14,7 @@ export interface MyCountData {
 export function getMyCountFetch(
   this: SDKFetch
 ): Observable<MyCountData> {
-  return this.get<MyCountData>(`/users/me/count`)
+  return this.get<MyCountData>(`users/me/count`)
 }
 
 SDKFetch.prototype.getMyCount = getMyCountFetch

--- a/src/apis/my/recent.ts
+++ b/src/apis/my/recent.ts
@@ -31,7 +31,7 @@ export function getMyRecentFetch(
   this: SDKFetch,
   query: MyRecentQuery
 ): Observable<RecentData[]> {
-  return this.get<RecentData[]>(`/users/recent`, query)
+  return this.get<RecentData[]>(`users/recent`, query)
 }
 
 SDKFetch.prototype.getMyRecent = getMyRecentFetch

--- a/src/apis/post/create.ts
+++ b/src/apis/post/create.ts
@@ -16,7 +16,7 @@ export interface CreatePostOptions {
 }
 
 export function createPostFetch(this: SDKFetch, options: CreatePostOptions): Observable<PostSchema> {
-  return this.post('/posts', options)
+  return this.post('posts', options)
 }
 
 SDKFetch.prototype.createPost = createPostFetch

--- a/src/apis/post/delete.ts
+++ b/src/apis/post/delete.ts
@@ -7,7 +7,7 @@ export function deletePostFetch (
   this: SDKFetch,
   _postId: PostId
 ) {
-  return this.delete(`/posts/delete/${_postId}`)
+  return this.delete(`posts/delete/${_postId}`)
 }
 
 SDKFetch.prototype.deletePost = deletePostFetch

--- a/src/apis/post/get.ts
+++ b/src/apis/post/get.ts
@@ -10,7 +10,7 @@ export function getPostFetch(
   postId: PostId,
   query?: any
 ): Observable<PostSchema> {
-  return this.get<PostSchema>(`/posts/${postId}`, query)
+  return this.get<PostSchema>(`posts/${postId}`, query)
 }
 
 SDKFetch.prototype.getPost = getPostFetch

--- a/src/apis/post/getByTagId.ts
+++ b/src/apis/post/getByTagId.ts
@@ -12,7 +12,7 @@ export function getByTagIdFetch(this: SDKFetch, tagId: TagId, query?: {
   fields?: string
   [index: string]: any
 }): Observable<PostSchema[]> {
-  return this.get(`/tags/${tagId}/posts`, query)
+  return this.get(`tags/${tagId}/posts`, query)
 }
 
 SDKFetch.prototype.getPostsByTagId = getByTagIdFetch

--- a/src/apis/post/getProjects.ts
+++ b/src/apis/post/getProjects.ts
@@ -21,7 +21,7 @@ export function getPostsFetch<T extends ProjectPostType>(
   _projectId: ProjectId,
   query: GetPostsQuery<T>
 ): Observable<PostSchema[]> {
-  return this.get(`/projects/${_projectId}/posts`, query)
+  return this.get(`projects/${_projectId}/posts`, query)
 }
 
 SDKFetch.prototype.getPosts = getPostsFetch

--- a/src/apis/task/get.ts
+++ b/src/apis/task/get.ts
@@ -10,7 +10,7 @@ export function getTaskFetch(
   taskId: TaskId,
   query?: any
 ): Observable<TaskSchema> {
-  return this.get<TaskSchema>(`/events/${taskId}`, query)
+  return this.get<TaskSchema>(`events/${taskId}`, query)
 }
 
 SDKFetch.prototype.getTask = getTaskFetch

--- a/src/apis/user/addEmail.ts
+++ b/src/apis/user/addEmail.ts
@@ -6,7 +6,7 @@ export function addEmailFetch (
   this: SDKFetch,
   email: string
 ): Observable<any> {
-  return this.post('/users/email', { email })
+  return this.post('users/email', { email })
 }
 
 SDKFetch.prototype.addEmail = addEmailFetch

--- a/src/apis/user/update.ts
+++ b/src/apis/user/update.ts
@@ -6,7 +6,7 @@ export function updateUserFetch<T> (
   this: SDKFetch,
   patch: T
 ): Observable<T> {
-  return this.put('/users', patch)
+  return this.put('users', patch)
 }
 
 SDKFetch.prototype.updateUser = updateUserFetch

--- a/src/utils/Fetch.ts
+++ b/src/utils/Fetch.ts
@@ -117,13 +117,13 @@ export class Fetch {
     return url + _query
   }
 
-  protected createMethod<T>(method: AllowedHttpMethod): (url: string, body?: any) => Observable<any> {
-    return (url: string, body?: any): Observable<T> => {
+  protected createMethod<T>(method: AllowedHttpMethod): (path: string, body?: any) => Observable<any> {
+    return (path: string, body?: any): Observable<T> => {
+      const url = `${this._apiHost}/${path}`
       /* istanbul ignore if */
       if (testable.UseXMLHTTPRequest && typeof window !== 'undefined') {
         return Observable.ajax({
-          url: this._apiHost + url,
-          body, method,
+          url, body, method,
           headers: this._opts.headers,
           withCredentials: this._opts.credentials === 'include',
           responseType: this._opts.responseType || 'json',
@@ -162,7 +162,7 @@ export class Fetch {
           if (body) {
             options.body = typeof body === 'object' ? JSON.stringify(body) : body
           }
-          fetch(this._apiHost + url, options)
+          fetch(url, options)
             .then((response: Response): Promise<string> => {
               if (response.status >= 200 && response.status < 400) {
                 return response.text()

--- a/test/mock/MockFetch.ts
+++ b/test/mock/MockFetch.ts
@@ -1,44 +1,54 @@
 import { Backend, SDKFetch } from '../index'
 
+function throwIfSlashPath(path: string) {
+  if (path.charAt(0) === '/') {
+    throw new Error(`There shouldn't be a slash before path (${path})`)
+  }
+}
+
 export class MockFetch extends SDKFetch {
   private httpBackend = new Backend
 
-  mockGet(url: string, query?: any) {
+  mockGet(path: string, query?: any) {
+    throwIfSlashPath(path)
     return (f: SDKFetch) => {
       const apiHost = f.getAPIHost()
       return {
-        mockResponse: this.httpBackend.whenGET(`${apiHost}${url}`, query),
-        request: this.get(url, query)
+        mockResponse: this.httpBackend.whenGET(`${apiHost}/${path}`, query),
+        request: this.get(path, query)
       }
     }
   }
 
-  mockPut(url: string, body?: any) {
+  mockPut(path: string, body?: any) {
+    throwIfSlashPath(path)
     return (f: SDKFetch) => {
       const apiHost = f.getAPIHost()
       return {
-        mockResponse: this.httpBackend.whenPUT(`${apiHost}${url}`, body),
-        request: this.put(url, body)
+        mockResponse: this.httpBackend.whenPUT(`${apiHost}/${path}`, body),
+        request: this.put(path, body)
       }
     }
   }
 
-  mockPost(url: string, body?: any) {
+  mockPost(path: string, body?: any) {
+    throwIfSlashPath(path)
     return (f: SDKFetch) => {
       const apiHost = f.getAPIHost()
       return {
-        mockResponse: this.httpBackend.whenPOST(`${apiHost}${url}`, body),
-        request: this.post(url, body)
+        mockResponse: this.httpBackend.whenPOST(`${apiHost}/${path}`, body),
+        request: this.post(path, body)
       }
     }
   }
 
-  mockDelete(url: string) {
+  mockDelete(path: string) {
+    throwIfSlashPath(path)
     return (f: SDKFetch) => {
       const apiHost = f.getAPIHost()
       return {
-        mockResponse: this.httpBackend.whenDELETE(`${apiHost}${url}`),
-        request: this.delete(url)
+        mockResponse: this.httpBackend.whenDELETE(`${apiHost}/${path}`),
+        request: this.delete(path)
       }
     }
   }

--- a/test/utils/fetch.ts
+++ b/test/utils/fetch.ts
@@ -9,6 +9,7 @@ const fetchMock = require('fetch-mock')
 export default describe('utils/fetch', () => {
 
   let fetchInstance: Fetch
+  const path = 'test'
 
   beforeEach(() => {
     fetchInstance = new Fetch()
@@ -22,7 +23,6 @@ export default describe('utils/fetch', () => {
   })
 
   it('should call isomophic fetch with the correct arguments', done => {
-    const path = '/test'
     const url = `${fetchInstance.getAPIHost()}${path}`
     const data = { test: 'test' }
     fetchMock.mock(url, data)
@@ -74,7 +74,6 @@ export default describe('utils/fetch', () => {
   it('should set token', done => {
     const token = 'test_token'
     const apiHost = 'https://www.teambition.com/api'
-    const path = '/test'
     const url = `${apiHost}${path}`
     fetchInstance.setToken(token)
     fetchMock.mock(url, {})
@@ -96,7 +95,6 @@ export default describe('utils/fetch', () => {
 
   ['get', 'post', 'put', 'delete'].forEach(httpMethod => {
     it(`should define ${httpMethod}`, done => {
-      const path = '/test'
       const url = `${fetchInstance.getAPIHost()}${path}`
       const responseData = { test: 'test' }
       const body = { body: 'body' }
@@ -119,7 +117,6 @@ export default describe('utils/fetch', () => {
   ['get', 'post', 'put', 'delete'].forEach(httpMethod => {
     [400, 401, 403, 404, 500].forEach(status => {
       it(`should handle ${status} status for ${httpMethod}`, done => {
-        const path = '/test'
         const url = `${fetchInstance.getAPIHost()}${path}`
         const responseData = { body: { test: 'test' }, method: httpMethod, status }
         const body = { body: 'body' }

--- a/test/utils/fetch.ts
+++ b/test/utils/fetch.ts
@@ -9,21 +9,22 @@ const fetchMock = require('fetch-mock')
 export default describe('utils/fetch', () => {
 
   let fetchInstance: Fetch
+  let url: string
   const path = 'test'
 
   beforeEach(() => {
     fetchInstance = new Fetch()
+    url = `${fetchInstance.getAPIHost()}/${path}`
   })
 
   it('should configure api host', () => {
     expect(fetchInstance.getAPIHost()).to.equal('https://www.teambition.com/api')
-    const url = 'https://www.example.com'
-    fetchInstance.setAPIHost(url)
-    expect(fetchInstance.getAPIHost()).to.equal(url)
+    const myUrl = 'https://www.example.com'
+    fetchInstance.setAPIHost(myUrl)
+    expect(fetchInstance.getAPIHost()).to.equal(myUrl)
   })
 
   it('should call isomophic fetch with the correct arguments', done => {
-    const url = `${fetchInstance.getAPIHost()}${path}`
     const data = { test: 'test' }
     fetchMock.mock(url, data)
     fetchInstance.get(path)
@@ -73,8 +74,6 @@ export default describe('utils/fetch', () => {
 
   it('should set token', done => {
     const token = 'test_token'
-    const apiHost = 'https://www.teambition.com/api'
-    const url = `${apiHost}${path}`
     fetchInstance.setToken(token)
     fetchMock.mock(url, {})
     fetchInstance.get(path)
@@ -95,7 +94,6 @@ export default describe('utils/fetch', () => {
 
   ['get', 'post', 'put', 'delete'].forEach(httpMethod => {
     it(`should define ${httpMethod}`, done => {
-      const url = `${fetchInstance.getAPIHost()}${path}`
       const responseData = { test: 'test' }
       const body = { body: 'body' }
       fetchMock.mock(url, JSON.stringify(responseData), {
@@ -117,7 +115,6 @@ export default describe('utils/fetch', () => {
   ['get', 'post', 'put', 'delete'].forEach(httpMethod => {
     [400, 401, 403, 404, 500].forEach(status => {
       it(`should handle ${status} status for ${httpMethod}`, done => {
-        const url = `${fetchInstance.getAPIHost()}${path}`
         const responseData = { body: { test: 'test' }, method: httpMethod, status }
         const body = { body: 'body' }
         fetchMock.mock(url, responseData )

--- a/test/utils/httpErrorSpec.ts
+++ b/test/utils/httpErrorSpec.ts
@@ -9,14 +9,16 @@ const expect = chai.expect
 export default describe('HttpError$ test: ', () => {
   let httpBackend: Backend
   let mockFetch: Fetch
-  let apiHost: string
+  let url: string
   let error$: Subject<HttpErrorMessage>
+
+  const path = 'users/me'
 
   beforeEach(() => {
     error$ = new Subject<HttpErrorMessage>()
     httpBackend = new Backend()
     mockFetch = new Fetch(error$)
-    apiHost = mockFetch.getAPIHost()
+    url = `${mockFetch.getAPIHost()}/${path}`
   })
 
   afterEach(() => {
@@ -24,7 +26,7 @@ export default describe('HttpError$ test: ', () => {
   })
 
   it('handler error should ok', done => {
-    httpBackend.whenGET(`${apiHost}users/me`)
+    httpBackend.whenGET(url)
       .error('Bad Request', {
         status: 400
       })
@@ -38,17 +40,17 @@ export default describe('HttpError$ test: ', () => {
         done()
       })
 
-    mockFetch.get('users/me').subscribe()
+    mockFetch.get(path).subscribe()
   })
 
   it('handler sequence error should ok', done => {
 
-    httpBackend.whenGET(`${apiHost}users/me`)
+    httpBackend.whenGET(url)
       .error('Bad Request', {
         status: 400
       })
 
-    httpBackend.whenGET(`${apiHost}users/me`)
+    httpBackend.whenGET(url)
       .error('Bad Request', {
         status: 400
       })
@@ -61,7 +63,7 @@ export default describe('HttpError$ test: ', () => {
         done()
       })
 
-    mockFetch.get('users/me').subscribe()
-    mockFetch.get('users/me').subscribe()
+    mockFetch.get(path).subscribe()
+    mockFetch.get(path).subscribe()
   })
 })


### PR DESCRIPTION
我理解的大方向是，希望将要成为 URL 组成部分的值左右两边不带斜杠，而将添加斜杠的活儿交给最终生成并使用完整 URL 的部件。

具体到这个 PR，一致化取消 path 字段前面所带的斜杠，修复之前因为有的 path 不加斜杠（如：posts），而有些加斜杠（如：projects），所带来的 bug。并在测试中添加检查。