### PR TITLE
DEV-2969: 配合分享墙重构，为 posts 的相关接口添加 orderBy 输入

### DIFF
--- a/src/utils/helper.ts
+++ b/src/utils/helper.ts
@@ -147,3 +147,14 @@ export function pagination(count: number, page: number) {
     skip: (count * (page - 1)),
   }
 }
+
+export function omit(o: any, ...properties: string[]) {
+  if (typeof o !== 'object' || o === null) {
+    return o
+  }
+  const obj = { ...o }
+  properties.forEach(p => {
+    delete obj[p]
+  })
+  return obj
+}

--- a/test/fixtures/posts.fixture.ts
+++ b/test/fixtures/posts.fixture.ts
@@ -1826,7 +1826,7 @@ export const projectPosts = [
   }
 ]
 
-export const myPorjectPosts = [
+export const myProjectPosts = [
   {
     _id: '58046e55f269088a418f8afa',
     postMode: 'html',

--- a/test/utils/utils.ts
+++ b/test/utils/utils.ts
@@ -7,7 +7,8 @@ import {
   concat,
   dropEle,
   capitalizeFirstLetter,
-  parseHeaders
+  parseHeaders,
+  omit
 } from '../index'
 
 const expect = chai.expect
@@ -245,6 +246,16 @@ export default describe('utils test', () => {
       'Connection': 'keep-alive',
       'Api-Server-IP': '10.75.0.71'
     })
+  })
+
+  it('omit should ok', () => {
+    const omitProps = (x) => omit(x, 'x', 'y')
+    expect(omitProps(0)).to.equal(0)
+    expect(omitProps(undefined)).to.be.undefined
+    expect(omitProps(null)).to.be.null
+    expect(omitProps({ x: 1 })).to.deep.equal({})
+    expect(omitProps({ z: 3 })).to.deep.equal({ z: 3 })
+    expect(omitProps({ x: 1, y: 2, z: 3 })).to.deep.equal({ z: 3 })
   })
 
 })


### PR DESCRIPTION
...不破坏现有测试。TODO: 添加相应测试。

DEV-2969: 添加测试

DEV-2969: 让 API 用户传入整个 orderBy 数组

...保持面对业务变动的灵活度。