### PR TITLE
fix(EventMaps): 不为找不到的表抛异常

### DIFF
--- a/src/sockets/EventMaps.ts
+++ b/src/sockets/EventMaps.ts
@@ -53,11 +53,8 @@ const handler = (
   const arg1 = capitalizeFirstLetter(type)
   const pkName = tabNameToPKName[arg1]
 
-  try {
-    // ensure table is defined
-    db.get(arg1)
-  } catch (err) {
-    SDKLogger.warn(`Not existTable: ${arg1}`)
+  if (!pkName) {
+    SDKLogger.warn(`Non-existent table: ${arg1}`)
     return Observable.of(null)
   }
 

--- a/test/app.ts
+++ b/test/app.ts
@@ -11,3 +11,4 @@ export * from './utils/httpErrorSpec'
 export * from './mock/MockSpec'
 
 import './apis'
+import './sockets'

--- a/test/sockets/index.ts
+++ b/test/sockets/index.ts
@@ -1,0 +1,1 @@
+import './sockets.spec'

--- a/test/sockets/sockets.spec.ts
+++ b/test/sockets/sockets.spec.ts
@@ -1,0 +1,29 @@
+import { describe, beforeEach, afterEach, it } from 'tman'
+import { expect } from 'chai'
+import { createSdk, SDK, SocketMock } from '../index'
+import { restore } from '../utils'
+import * as sinon from 'sinon'
+import { Logger } from 'reactivedb'
+
+describe('Socket handling Spec', () => {
+  let sdk: SDK
+  let socket: SocketMock
+
+  beforeEach(() => {
+    sdk = createSdk()
+    socket = new SocketMock(sdk.socketClient)
+  })
+
+  afterEach(() => {
+    restore(sdk)
+  })
+
+  it('should warn but not throw when the target table is non-existent', function* () {
+    const logger = Logger.get('teambition-sdk')
+    const spy = sinon.spy(logger, 'warn')
+    const tx: any = 'Non-existent-table'
+    yield socket.emit('new', tx, '', {})
+    expect(spy).to.be.calledWith(`Non-existent table: ${tx}`)
+    spy.restore()
+  })
+})


### PR DESCRIPTION
先前使用 rdb 的 Database.prototype.get 方法来检查，不能同步地（synchronously）得知找不到表的问题，于是 try...catch 的结构无效。