### PR TITLE
feat(async-load-rdb): 支持异步加载reactivedb

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "tslib": "^1.6.0"
   },
   "dependencies": {
-    "reactivedb": "^0.8.1"
+    "reactivedb": "^0.9.0"
   },
   "devDependencies": {
     "@types/chai": "^3.4.34",

--- a/src/Net/Net.ts
+++ b/src/Net/Net.ts
@@ -1,0 +1,296 @@
+import { Observable } from 'rxjs/Observable'
+import { BehaviorSubject } from 'rxjs/BehaviorSubject'
+import { forEach } from '../utils'
+import {
+  Database,
+  SchemaDef,
+  Query,
+  Clause,
+  ExecutorResult
+} from 'reactivedb'
+
+import Dirty from '../utils/Dirty'
+
+import { QueryToken, SelectorMeta } from 'reactivedb/proxy'
+import { ProxySelector } from 'reactivedb/proxy'
+
+const ctx = typeof global === 'undefined' ? window : global
+
+export enum CacheStrategy {
+  Request = 200,
+  Cache,
+  Pass
+}
+
+export interface ApiResult<T, U extends CacheStrategy> {
+  request: Observable<T[]> | Observable<T>
+  query: Query<T>
+  tableName: string
+  cacheValidate: U
+  assocFields?: AssocField<T>
+  excludeFields?: string[]
+}
+
+export type AssocField<T> = {
+  [P in keyof T]?: AssocField<T[P]> | string[]
+}
+
+export interface CApiResult<T> {
+  request: Observable<T>
+  tableName: string
+  method: 'create'
+}
+
+export interface UDResult<T> {
+  request: Observable<T>
+  tableName: string
+  method: 'update' | 'delete'
+  clause: Clause<T>
+}
+
+export type CUDApiResult<T> = CApiResult<T> | UDResult<T>
+
+export class Net {
+  constructor(
+    schemas: { schema: SchemaDef<any>, name: string }[],
+    public database: Database = undefined,
+    public fields = new Map<string, string[]>(),
+    private requestMap = new Map<string, boolean>(),
+    private CUDBuffer: Object[] = [],
+    private socketCUDBuffer: Object[] = [],
+    private proxySelectorBuffer: BehaviorSubject<SelectorMeta<any>>[] = [],
+    private realSelectorInfoBuffer: Object[] = [] // use to construct real selector
+  ) {
+    forEach(schemas, d => {
+      this.fields.set(d.name, Object.keys(d.schema).filter(k => !d.schema[k].virtual))
+    })
+  }
+
+  lift<T>(result: ApiResult<T, CacheStrategy.Cache>): QueryToken<T>
+
+  lift<T>(result: ApiResult<T, CacheStrategy.Request>): QueryToken<T>
+
+  lift<T>(result: ApiResult<T, CacheStrategy.Pass>): Observable<T> | Observable<T[]>
+
+  lift<T>(result: CUDApiResult<T>): Observable<T>
+
+  lift<T>(result: ApiResult<T, CacheStrategy> | CUDApiResult<T>) {
+    if ((result as ApiResult<T, CacheStrategy>).cacheValidate) {
+      return this.handleApiResult<T>(result as ApiResult<T, CacheStrategy>)
+    } else {
+      return this.handleCUDAResult<T>(result as CUDApiResult<T>)
+    }
+  }
+
+  private getInfoFromResult<T>(result: ApiResult<T, CacheStrategy>) {
+    const {
+      query,
+      tableName,
+      cacheValidate,
+      request,
+      assocFields,
+      excludeFields
+    } = result as ApiResult<T, CacheStrategy>
+    const preDefinedFields = this.fields.get(tableName)
+    if (!preDefinedFields) {
+      throw new Error(`table: ${tableName} is not defined`)
+    }
+    const fields: string[] = []
+    if (assocFields) {
+      fields.push(assocFields as any)
+    }
+    const set = new Set(excludeFields)
+    forEach(this.fields.get(tableName), f => {
+      if (!set.has(f)) {
+        fields.push(f)
+      }
+    })
+    const q: Query<T> = { ...query, fields }
+    return { request, q, cacheValidate, tableName }
+  }
+
+  handleApiResult<T>(result: ApiResult<T, CacheStrategy>) {
+    if (!this.database) { return this.bufferResponse(result) }
+    const {
+      request,
+      q,
+      cacheValidate,
+      tableName
+    } = this.getInfoFromResult(result)
+
+    const sq = JSON.stringify(q)
+    const requestCache = this.requestMap.get(sq)
+    switch (cacheValidate) {
+      case CacheStrategy.Request:
+        if (!requestCache) {
+          const selectMeta$ = request
+            .concatMap<T | T[], T>(v => this.database.upsert(tableName, v))
+            .do(() => this.requestMap.set(sq, true))
+            .concatMap(() => this.database.get<T>(tableName, q).selector$)
+          return new QueryToken<T[]>(<any>selectMeta$)
+        } else {
+          return this.database.get<T>(tableName, q)
+        }
+      case CacheStrategy.Cache:
+        const selectMeta$ = this.database
+          .get<T>(tableName, q)
+          .values()
+          .concatMap<T[], any>((cache: T[]) => {
+            if (cache.length) {
+              return this.database
+                .get<T>(tableName, q)
+                .selector$
+            } else {
+              return request.concatMap<T | T[], T>(val => {
+                return this.database.upsert(tableName, val)
+                  .concatMap(() => this.database.get<T>(tableName, q).selector$)
+              })
+            }
+          })
+        return new QueryToken(selectMeta$)
+      case CacheStrategy.Pass:
+      default:
+        return request
+    }
+  }
+
+  handleCUDAResult<T>(result: CUDApiResult<T>) {
+    if (!this.database) { return this.bufferCUDResponse(result) }
+
+    const { request, method, tableName } = result as CUDApiResult<T>
+    let destination: Observable<ExecutorResult> | Observable<T | T[]>
+    return request
+      .concatMap(v => {
+        switch (method) {
+          case 'create':
+            destination = this.database.upsert<T>(tableName, v)
+            break
+          case 'update':
+            destination = this.database.upsert(tableName, v)
+            break
+          case 'delete':
+            destination = this.database.delete<T>(tableName, (result as UDResult<T>).clause)
+            break
+          default:
+            throw new Error()
+        }
+        return destination.mapTo<ExecutorResult | T | T[], T>(v)
+      })
+  }
+
+  public persist<T>(database: Database) {
+    if (!this.database) { this.database = database }
+    const asyncQueue: Promise<void>[] = []
+    forEach(this.realSelectorInfoBuffer, (v: any, idx) => {
+      const q = v.q
+      const sq = JSON.stringify(v.q)
+      const request = v.request
+      const tableName = v.tableName
+      const proxySelector = this.proxySelectorBuffer[idx]
+      if (v.type === CacheStrategy.Request) {
+        const p = (request as Observable<T[]> | Observable<T>)
+          .concatMap<T | T[], T>(val => database.upsert(tableName, val))
+          .do(() => this.requestMap.set(sq, true))
+          .concatMap(() => database.get<T>(tableName, q).selector$)
+          .toPromise()
+          .then((result: SelectorMeta<T>) => proxySelector.next(result))
+        asyncQueue.push(p)
+      } else if (v.type === CacheStrategy.Cache) {
+        const p = (request as Observable<T[]> | Observable<T>)
+          .concatMap<T | T[], T>(val => database.upsert(tableName, val))
+          .concatMap(() => database.get<T>(tableName, q).selector$)
+          .toPromise()
+          .then((result: SelectorMeta<T>) => proxySelector.next(result))
+        asyncQueue.push(p)
+      }
+    })
+
+    this.realSelectorInfoBuffer = []
+    this.proxySelectorBuffer = []
+
+    forEach(this.CUDBuffer, (v: any) => {
+      const p = database[v.method](v.tableName, v.value)
+        .toPromise()
+        .then(null, (err: any) => ctx['console']['error'](err))
+      asyncQueue.push(p)
+    })
+
+    forEach(this.socketCUDBuffer, (v: any) => {
+      const db = this.database
+      const socketMessage = v.socketMessage
+      const type = v.type
+      const arg = v.arg
+      const pkName = v.pkName
+      if (socketMessage.method === 'destroy' || socketMessage.method === 'remove') {
+        const p = db.delete(arg, {
+          where: { [pkName]: socketMessage.id || socketMessage.data }
+        })
+          .toPromise()
+          .then(null, (err: any) => ctx['console']['error'](err))
+        asyncQueue.push(p)
+      } else if (socketMessage.method === 'new') {
+        const p = db.upsert(arg, socketMessage.data)
+          .toPromise()
+          .then(null, (err: any) => ctx['console']['error'](err))
+        asyncQueue.push(p)
+      } else if (socketMessage.method === 'change') {
+        const dirtyStream = Dirty.handlerSocketMessage(socketMessage.id, type, socketMessage.data, db)
+        if (dirtyStream) {
+          const p = dirtyStream
+            .toPromise()
+            .then(null, (err: any) => ctx['console']['error'](err))
+          asyncQueue.push(p)
+        } else {
+          const p = db.upsert(arg, {
+            ...socketMessage.data,
+            [pkName]: socketMessage.id
+          })
+            .toPromise()
+            .then(null, (err: any) => ctx['console']['error'](err))
+          asyncQueue.push(p)
+        }
+      }
+    })
+    this.socketCUDBuffer = []
+    return Observable.from(asyncQueue)
+  }
+
+  public bufferResponse<T>(result: ApiResult<T, CacheStrategy>) {
+
+    const {
+    request,
+      q,
+      cacheValidate,
+      tableName
+  } = this.getInfoFromResult(result)
+
+    const proxySelector = new ProxySelector<T>(request, q, tableName)
+    const proxySelector$ = new BehaviorSubject(proxySelector)
+
+    this.realSelectorInfoBuffer.push({ request, q, tableName, type: cacheValidate })
+    this.proxySelectorBuffer.push(proxySelector$)
+    return new QueryToken(proxySelector$)
+  }
+
+  public bufferCUDResponse<T>(result: CUDApiResult<T>) {
+    const { request, method, tableName } = result as CUDApiResult<T>
+    return request.do((v: T | T[]) => {
+      this.CUDBuffer.push({
+        tableName,
+        method: ((method === 'create' || method === 'update') ? 'upsert' : method),
+        value: method === 'delete' ? (result as UDResult<T>).clause : v
+      })
+    })
+  }
+
+  public bufferSocketPush(
+    arg: string,
+    socketMessage: Object,
+    pkName: string,
+    type: any
+  ) {
+    this.socketCUDBuffer.push({ arg, socketMessage, pkName, type })
+    return Observable.of(null)
+  }
+
+}

--- a/src/Net/index.ts
+++ b/src/Net/index.ts
@@ -1,0 +1,1 @@
+export * from './Net'

--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -3,17 +3,15 @@ import 'rxjs/add/operator/do'
 import 'rxjs/add/operator/mapTo'
 import { Observable } from 'rxjs/Observable'
 import {
-  Database,
-  Query,
-  QueryToken,
-  Clause,
-  ExecutorResult
+  Database
 } from 'reactivedb'
+import { Net } from './Net'
 
 import { forEach } from './utils'
 import { SDKFetch } from './SDKFetch'
 import { SocketClient } from './sockets/SocketClient'
 import { SchemaColl } from './utils/internalTypes'
+
 
 export enum CacheStrategy {
   Request = 200,
@@ -21,150 +19,32 @@ export enum CacheStrategy {
   Pass
 }
 
-export interface ApiResult<T, U extends CacheStrategy> {
-  request: Observable<T[]> | Observable<T>
-  query: Query<T>
-  tableName: string
-  cacheValidate: U
-  assocFields?: AssocField<T>
-  excludeFields?: string[]
-}
-
-export type AssocField<T> = {
-  [P in keyof T]?: AssocField<T[P]> | string[]
-}
-
-export interface CApiResult<T> {
-  request: Observable<T>
-  tableName: string
-  method: 'create'
-}
-
-export interface UDResult<T> {
-  request: Observable<T>
-  tableName: string
-  method: 'update' | 'delete'
-  clause: Clause<T>
-}
-
-export type CUDApiResult<T> = CApiResult<T> | UDResult<T>
-
 export const schemas: SchemaColl = []
 
 export class SDK {
+  public net: Net
   fetch = new SDKFetch
   socketClient: SocketClient
-  public fields = new Map<string, string[]>()
-  private requestMap = new Map<string, boolean>()
+  public database: Database
 
-  constructor(
-    public database: Database
-  ) {
+  constructor() {
+    this.net = new Net(schemas)
+    this.socketClient = new SocketClient(this.fetch, this.net, schemas)
+  }
+
+  initReactiveDB (db: Database): Observable<Promise<void>> {
+    this.database = db
     forEach(schemas, d => {
-      database.defineSchema(d.name, d.schema)
-      this.fields.set(d.name, Object.keys(d.schema).filter(k => !d.schema[k].virtual))
+      this.database.defineSchema(d.name, d.schema)
     })
-    database.connect()
-    this.socketClient = new SocketClient(database, this.fetch, schemas)
+    this.database.connect()
+
+    this.socketClient.initReactiveDB(this.database)
+    return this.net.persist(this.database)
   }
 
-  lift<T>(result: ApiResult<T, CacheStrategy.Cache>): QueryToken<T>
-
-  lift<T>(result: ApiResult<T, CacheStrategy.Request>): QueryToken<T>
-
-  lift<T>(result: ApiResult<T, CacheStrategy.Pass>): Observable<T> | Observable<T[]>
-
-  lift<T>(result: CUDApiResult<T>): Observable<T>
-
-  lift<T>(result: ApiResult<T, CacheStrategy> | CUDApiResult<T>) {
-    if ((result as ApiResult<T, CacheStrategy>).cacheValidate) {
-      return this.handleApiResult<T>(result as ApiResult<T, CacheStrategy>)
-    } else {
-      return this.handleCUDAResult<T>(result as CUDApiResult<T>)
-    }
-  }
-
-  handleApiResult<T>(result: ApiResult<T, CacheStrategy>) {
-    const {
-      query,
-      tableName,
-      cacheValidate,
-      request,
-      assocFields,
-      excludeFields
-    } = result as ApiResult<T, CacheStrategy>
-    const preDefinedFields = this.fields.get(tableName)
-    if (!preDefinedFields) {
-      throw new Error(`table: ${tableName} is not defined`)
-    }
-    const fields: string[] = []
-    if (assocFields) {
-      fields.push(assocFields as any)
-    }
-    const set = new Set(excludeFields)
-    forEach(this.fields.get(tableName), f => {
-      if (!set.has(f)) {
-        fields.push(f)
-      }
-    })
-    const q = { ...query, fields }
-    const sq = JSON.stringify(q)
-    const requestCache = this.requestMap.get(sq)
-    switch (cacheValidate) {
-      case CacheStrategy.Request:
-        if (!requestCache) {
-          const selectMeta$ = request
-            .concatMap<T | T[], T>(v => this.database.upsert(tableName, v))
-            .do(() => this.requestMap.set(sq, true))
-            .concatMap(() => this.database.get<T>(tableName, q).selector$)
-          return new QueryToken<T[]>(<any>selectMeta$)
-        } else {
-          return this.database.get<T>(tableName, q)
-        }
-      case CacheStrategy.Cache:
-        const selectMeta$ = this.database
-          .get<T>(tableName, q)
-          .values()
-          .concatMap<T[], any>(cache => {
-            if (cache.length) {
-              return this.database
-                .get<T>(tableName, q)
-                .selector$
-            } else {
-              return request.concatMap<T | T[], T>(val => {
-                return this.database.upsert(tableName, val)
-                  .concatMap(() => this.database.get<T>(tableName, q).selector$)
-              })
-            }
-          })
-        return new QueryToken(selectMeta$)
-      case CacheStrategy.Pass:
-      default:
-        return request
-    }
-  }
-
-  handleCUDAResult<T>(result: CUDApiResult<T>) {
-    const { request, method, tableName } = result as CUDApiResult<T>
-    let destination: Observable<ExecutorResult> | Observable<T | T[]>
-
-    return request
-      .concatMap(v => {
-        switch (method) {
-          case 'create':
-            destination = this.database.upsert<T>(tableName, v)
-            break
-          case 'update':
-            destination = this.database.upsert(tableName, v)
-            break
-          case 'delete':
-            destination = this.database.delete<T>(tableName, (result as UDResult<T>).clause)
-            break
-          default:
-            throw new Error()
-        }
-        return destination.mapTo<ExecutorResult | T | T[], T>(v)
-      })
+  get lift(): typeof Net.prototype.lift {
+    return this.net.lift.bind(this.net)
   }
 
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,5 +16,6 @@ export * from './schemas'
 
 export { SDK } from './SDK'
 export { SDKFetch } from './SDKFetch'
+export { Net, CacheStrategy } from './Net'
 
 // export const SocketClient: Client = sdk.socket

--- a/test/app.ts
+++ b/test/app.ts
@@ -12,3 +12,4 @@ export * from './mock/MockSpec'
 
 import './apis'
 import './sockets'
+import './async-rdb'

--- a/test/async-rdb/async-rdb.spec.ts
+++ b/test/async-rdb/async-rdb.spec.ts
@@ -1,0 +1,215 @@
+import { describe, beforeEach, afterEach, it } from 'tman'
+import { expect } from 'chai'
+import {
+  createSdkWithoutRDB,
+  loadRDB,
+  SDK,
+  TaskSchema,
+  PostSchema,
+  LikeSchema,
+  SocketMock
+} from '../index'
+import { projectPosts } from '../fixtures/posts.fixture'
+import like from '../fixtures/like.fixture'
+import userMe from '../fixtures/user.fixture'
+import { task } from '../fixtures/tasks.fixture'
+import { myRecent } from '../fixtures/my.fixture'
+import { EventGenerator } from '../../src/apis/event/EventGenerator'
+
+import { mock, restore, equals } from '../utils'
+
+describe('Async load reactivedb Spec', () => {
+  let sdk: SDK
+  let mockResponse: <T>(m: T, delay?: number | Promise<any>) => void
+  let socket: SocketMock
+
+  const userId = myRecent[0]['_executorId']
+
+
+  beforeEach(() => {
+    sdk = createSdkWithoutRDB()
+    socket = new SocketMock(sdk.socketClient)
+    mockResponse = mock(sdk)
+  })
+
+  afterEach(() => {
+    restore(sdk)
+  })
+
+  describe('No reactivedb request spec', () => {
+    it('getPost should response correct data without reactivedb', function* () {
+      const [fixture] = projectPosts
+
+      mockResponse(fixture)
+      yield sdk.getPost(fixture._id)
+        .values()
+        .do(([r]) => {
+          expect(r).to.deep.equal(fixture)
+        })
+
+    })
+
+    it('getLike should response correct data without reactivedb', done => {
+      mockResponse(like)
+      sdk.getLike('task', 'mocktask')
+        .values()
+        .subscribe(([r]) => {
+          delete r._id
+          expect(r).to.deep.equal(like)
+          done()
+        })
+    })
+
+    it('getUser should response correct data without reactivedb', function* () {
+      mockResponse(userMe)
+
+      yield sdk.getUserMe()
+        .values()
+        .do(([user]) => {
+          expect(user).to.deep.equal(userMe)
+        })
+    })
+
+    it('getTask should response correct data without reactivedb', function* () {
+      const fixture = task
+      mockResponse(fixture)
+      yield sdk.getTask(fixture._id)
+        .values()
+        .do(([r]) => {
+          expect(r).to.deep.equal(fixture)
+        })
+    })
+  })
+  describe('ReactiveDB async load in', () => {
+
+    it('getMyRecent should response correct data when reactivedb async load in', function* () {
+      mockResponse(myRecent)
+
+      const token = sdk.getMyRecent(userId, {
+        dueDate: '2017-02-13T03:38:54.252Z',
+        startDate: '2016-12-31T16:00:00.000Z'
+      })
+
+      loadRDB(sdk)
+
+      yield token.values()
+        .do(r => {
+          const compareFn = (x, y) => {
+            return new Date(x.updated).valueOf() - new Date(y.updated).valueOf()
+              + new Date(x.created).valueOf() - new Date(y.created).valueOf()
+          }
+          const expected = myRecent.sort(compareFn)
+          const actual = r.map(_r => {
+            if (_r.type === 'task') {
+              if (!(_r as TaskSchema).recurrence) {
+                delete (_r as TaskSchema)._sourceId
+                delete (_r as TaskSchema).recurrence
+                delete (_r as TaskSchema).sourceDate
+              }
+              if (!(_r as TaskSchema).uniqueId) {
+                delete (_r as TaskSchema).uniqueId
+              }
+            }
+            if (_r instanceof EventGenerator) {
+              const dist = _r.next().value
+              dist._id = dist._sourceId
+              return dist
+            }
+            return _r
+          })
+            .sort(compareFn)
+
+          expect(actual).to.deep.equal(expected)
+        })
+    })
+
+    it('response cache should work when reactivedb async load in', function* () {
+      const [fixture] = projectPosts
+
+      mockResponse(fixture)
+      yield sdk.getPost(fixture._id)
+        .values()
+
+      yield loadRDB(sdk)
+
+      yield sdk.database.get<PostSchema>('Post', { where: { _id: fixture._id } })
+        .values()
+        .do((r) => {
+          expect(r.length).to.equal(1)
+        })
+    })
+
+    it('reactiveDb opearator should work when reactivedb load in', function* () {
+      mockResponse({
+        ...like, isLike: false, _id: 'mocktask:like'
+      })
+
+      yield sdk.getLike('task', 'mocktask')
+        .values()
+
+      yield sdk.toggleLike('task', 'mocktask', true)
+
+      yield loadRDB(sdk)
+
+      yield sdk.database.get<LikeSchema>('Like', {
+        where: { _id: 'mocktask:like' }
+      })
+        .values()
+        .do(([r]) => {
+          expect(r.isLike).to.be.false
+        })
+    })
+
+    describe('Socket spec when reactivedb async load in', () => {
+      it('socket::destroy should work when reactivedb load in', function* () {
+        const [fixture] = projectPosts
+
+        mockResponse(fixture)
+        yield sdk.getPost(fixture._id)
+          .values()
+        yield socket.emit('destroy', 'post', fixture._id)
+
+        yield loadRDB(sdk)
+
+        yield sdk.database.get<PostSchema>('Post', { where: { _id: fixture._id } })
+          .values()
+          .do((r) => {
+            expect(r.length).to.equal(0)
+          })
+      })
+
+      it('socket::change should work when reactivedb load in', function* () {
+        const [fixture] = projectPosts
+
+        mockResponse(fixture)
+        yield sdk.getPost(fixture._id)
+          .values()
+
+        yield socket.emit('change', 'post', fixture._id, {
+          // 这边不提供主键信息，以确定当 socket 消息的 d 部分不
+          // 包含主键信息时，前端依然可以顺利操作。
+          content: 'fixture'
+        })
+
+        yield loadRDB(sdk)
+
+        yield sdk.database.get<PostSchema>('Post', { where: { _id: fixture._id } })
+          .values()
+          .do(([r]) => expect(r.content).to.equal('fixture'))
+      })
+
+      it('socket::new should work when reactivedb load in', function* () {
+        const [fixture] = projectPosts
+
+        yield socket.emit('new', 'post', '', fixture)
+
+        yield loadRDB(sdk)
+
+        yield sdk.database.get('Post', { where: { _id: fixture._id } })
+          .values()
+          .do((r) => equals(r, [fixture]))
+      })
+    })
+
+  })
+})

--- a/test/async-rdb/index.ts
+++ b/test/async-rdb/index.ts
@@ -1,0 +1,1 @@
+import './async-rdb.spec'

--- a/test/index.ts
+++ b/test/index.ts
@@ -6,10 +6,21 @@ import { SDK } from '../src/index'
 testable.UseXMLHTTPRequest = false
 
 export function createSdk() {
-  const sdk = new SDK(
-    new Database(DataStoreType.MEMORY, false, 'teambition-sdk', 1)
-  )
+  const sdk = new SDK()
+
+  const database = new Database(DataStoreType.MEMORY, false, 'teambition-sdk', 1)
+  sdk.initReactiveDB(database)
+
   return sdk
+}
+
+export function createSdkWithoutRDB() {
+  return new SDK()
+}
+
+export function loadRDB(sdk: SDK) {
+  const database = new Database(DataStoreType.MEMORY, false, 'teambition-sdk', 1)
+  return sdk.initReactiveDB(database)
 }
 
 export * from '../src/index'


### PR DESCRIPTION
- 从`SDK.ts`中把请求处理剥离出来(`src/Net/`)
- `ReactiveDB`异步加载对请求的处理主要在三个部分

  1. `getPost`这样的`http`请求
  2. `toggleLike`这样的直接对`ReactiveDB`操作的请求
  3. `websocket`推送的操作(创建，更改，删除...)

- 添加测试`test/async-rdb`
- 实现细节上，主要是当`ReactiveDB`没进来的时候对三种请求的操作及其参数放进三个`queue`里，进来了以后按顺序把`queue`里的操作`patch`进`ReactiveDB`。为了在`ReactiveDB`没进来的时候依然能正常拿到数据，把`request`流包进假的`selector`(`proxySelector`)中构建`QueryToken`，等`ReactiveDB`进来了以后`switchMap`到真的`QueryToken`。



