### PR TITLE
fix(eventParser): 兼容 event string 不带前置冒号的情况

### DIFF
--- a/src/sockets/EventParser.ts
+++ b/src/sockets/EventParser.ts
@@ -1,5 +1,6 @@
 import { RequestEvent } from 'snapper-consumer'
 import { forEach } from '../utils/index'
+import Dirty from '../utils/Dirty'
 
 export interface MessageResult {
   // new change destroy refresh ...
@@ -28,7 +29,8 @@ export function eventParser(event: RequestEvent) {
         } catch (e) {
           return console.error(e)
         }
-        const methodAndData: MessageResult = parser(result.e)
+        const eventStr = Dirty.prefixWithColonIfItIsMissing(result.e)
+        const methodAndData: MessageResult = parser(eventStr)
         methodAndData.data = result.d
         methodAndDatas.push(methodAndData)
       })

--- a/src/utils/Dirty.ts
+++ b/src/utils/Dirty.ts
@@ -67,6 +67,16 @@ export class Dirty {
 
     return pkName
   }
+
+  prefixWithColonIfItIsMissing(eventStr: string) {
+    if (!eventStr.length) {
+      return ':'
+    }
+    if (eventStr.charAt(0) !== ':') {
+      return ':' + eventStr
+    }
+    return eventStr
+  }
 }
 
 export default new Dirty

--- a/test/sockets/eventParser.spec.ts
+++ b/test/sockets/eventParser.spec.ts
@@ -1,0 +1,43 @@
+import { eventParser, RequestEvent } from '../index'
+import { describe, beforeEach, it } from 'tman'
+import { expect } from 'chai'
+
+describe('eventParser', () => {
+
+  let event: RequestEvent
+  
+  beforeEach(() => {
+    event = {
+      id: 1,
+      type: 'request',
+      data: {
+        id: 1,
+        jsonrpc: '',
+        method: 'publish',
+        params: []
+      }
+    }
+  })
+  
+  it('handles example correctly', () => {
+    event.data.params.push("{\"e\":\":change:project/574bdf1c09bf88bd4f1dbb02\",\"d\":{\"uniqueIdPrefix\":\"QYGz\"}}")
+
+    expect(eventParser(event)).to.deep.equal([{
+      method: 'change',
+      id: '574bdf1c09bf88bd4f1dbb02',
+      type: 'project',
+      data: { uniqueIdPrefix: 'QYGz' }
+    }])
+  })
+
+  it('handles event strings that aren\'t prefixed with colon', () => {
+    event.data.params.push("{\"e\":\"system:notifications\",\"d\":{\"name\":\"taskUniqueId\",\"status\":\"success\"}}")
+
+    expect(eventParser(event)).to.deep.equal([{
+      method: 'system',
+      id: '',
+      type: 'notifications',
+      data: { name: 'taskUniqueId', status: 'success' }
+    }])
+  })
+})

--- a/test/sockets/index.ts
+++ b/test/sockets/index.ts
@@ -1,1 +1,2 @@
 import './sockets.spec'
+import './eventParser.spec'


### PR DESCRIPTION
...并添加测试。