### PR TITLE
fix(EventGenerator): next 能处理初始startDate被exclude的重复日程

### DIFF
--- a/src/apis/event/EventGenerator.ts
+++ b/src/apis/event/EventGenerator.ts
@@ -32,11 +32,13 @@ export class EventGenerator implements IterableIterator<EventSchema> {
       return { value: clone(this.event), done: true }
     }
     const target = clone(this.event)
-    const startDateVal = this.startDate.valueOf()
-    const afterDate = this.rrule.after(this.startDate)
+    const startDate = this.rrule.after(this.startDate, true)
+    const startDateVal = startDate.valueOf()
+    const endDate = new Date(startDateVal + this.interval)
+    const afterDate = this.rrule.after(endDate, true)
     target._id = `${target._id}_${startDateVal}`
-    target.startDate = this.startDate.toISOString()
-    target.endDate = new Date(startDateVal + this.interval).toISOString()
+    target.startDate = startDate.toISOString()
+    target.endDate = endDate.toISOString()
     const result = {
       done: !afterDate,
       value: target

--- a/test/apis/EventGenerator.spec.ts
+++ b/test/apis/EventGenerator.spec.ts
@@ -4,6 +4,7 @@ import * as Moment from 'moment'
 import {
   recurrenceByMonth,
   recurrenceHasEnd,
+  recurrenceStartAtAnExcludedDate,
   normalEvent
 } from '../fixtures/events.fixture'
 import { EventGenerator } from '../../src/apis/event/EventGenerator'
@@ -67,6 +68,17 @@ describe('EventGenerator spec', () => {
       }
       expect(next.done).to.false
     }
+  })
+
+  it('next should start correctly when the recurrence starts at an excluded date', () => {
+    const egen = new EventGenerator(recurrenceStartAtAnExcludedDate as any)
+    const actual = egen.next().value
+    delete actual['_id']
+    const expected = clone(recurrenceStartAtAnExcludedDate)
+    delete expected['_id']
+    expected.startDate = '2017-06-07T09:00:00.000Z'
+    expected.endDate = '2017-06-07T10:00:00.000Z'
+    expect(actual).to.deep.equal(expected)
   })
 
   it('takeUntil an out range Date should return empty array', () => {

--- a/test/apis/my.spec.ts
+++ b/test/apis/my.spec.ts
@@ -36,7 +36,7 @@ describe('MyApi Spec', () => {
             return new Date(x.updated).valueOf() - new Date(y.updated).valueOf()
              + new Date(x.created).valueOf() - new Date(y.created).valueOf()
           }
-          const expected = Fixture.myRecent.sort(compareFn)
+          const expected = Fixture.norm(Fixture.myRecent).sort(compareFn)
           const actual = r.map(_r => {
             if (_r.type === 'task') {
               if (!(_r as TaskSchema).recurrence) {
@@ -49,9 +49,7 @@ describe('MyApi Spec', () => {
               }
             }
             if (_r instanceof EventGenerator) {
-              const dist = _r.next().value
-              dist._id = dist._sourceId
-              return dist
+              return _r.next().value
             }
             return _r
           })

--- a/test/fixtures/events.fixture.ts
+++ b/test/fixtures/events.fixture.ts
@@ -132,6 +132,32 @@ export const recurrenceHasEnd = {
   isFavorite: false
 }
 
+export const recurrenceStartAtAnExcludedDate = {
+  _id: '592e8be1540a55e5d9200d9e',
+  endDate: '2017-05-31T10:00:00.000Z',
+  startDate: '2017-05-31T09:00:00.000Z',
+  _projectId: '574bdf1c09bf88bd4f1dbb02',
+  location: '',
+  content: '',
+  title: 'weekly',
+  _creatorId: '55c02018fd0360a44c93ff97',
+  tagIds: [],
+  updated: '2017-05-31T09:25:05.245Z',
+  created: '2017-05-31T09:24:49.043Z',
+  visible: 'members',
+  isArchived: false,
+  involveMembers: ['55c02018fd0360a44c93ff97'],
+  status: '',
+  untilDate: null,
+  _sourceId: '592e8be1540a55e5d9200d9e',
+  sourceDate: '2017-05-31T09:00:00.000Z',
+  recurrence: ['RRULE:FREQ=WEEKLY;DTSTART=20170531T090000Z;INTERVAL=1', 'EXDATE:20170531T090000Z'],
+  reminders: [],
+  objectlinksCount: 0,
+  isFavorite: false,
+  shareStatus: 0
+}
+
 export const projectEvents = [
   {
     _id: '579033c828bb08a462fe352c',

--- a/test/fixtures/my.fixture.ts
+++ b/test/fixtures/my.fixture.ts
@@ -1,3 +1,19 @@
+import { EventSchema } from '../index'
+import { EventGenerator } from '../../src/apis/event/EventGenerator'
+
+export function norm(myRecent: any[]): any[] {
+  const transFns: any[] = [firstOfARecurrentEvent]
+  return myRecent.map((x) => transFns.reduce((y, f) => f(y), x))
+}
+
+function firstOfARecurrentEvent(recent: any): any | EventSchema {
+  if (!recent.recurrence || !recent.recurrence.length || recent.type === 'task') {
+    return recent
+  }
+  const egen = new EventGenerator(recent)
+  return egen.next().value
+}
+
 export const myRecent = [
   {
     _id: '5698933d78eaa265030f9c37',

--- a/test/net/async-rdb.spec.ts
+++ b/test/net/async-rdb.spec.ts
@@ -14,7 +14,7 @@ import { projectPosts } from '../fixtures/posts.fixture'
 import like from '../fixtures/like.fixture'
 import userMe from '../fixtures/user.fixture'
 import { task } from '../fixtures/tasks.fixture'
-import { myRecent } from '../fixtures/my.fixture'
+import * as myFixture from '../fixtures/my.fixture'
 import { EventGenerator } from '../../src/apis/event/EventGenerator'
 
 import { mock, restore, equals } from '../utils'
@@ -24,7 +24,7 @@ describe('Async load reactivedb Spec', () => {
   let mockResponse: <T>(m: T, delay?: number | Promise<any>) => void
   let socket: SocketMock
 
-  const userId = myRecent[0]['_executorId']
+  const userId = myFixture.myRecent[0]['_executorId']
 
   beforeEach(() => {
     sdk = createSdkWithoutRDB()
@@ -86,7 +86,7 @@ describe('Async load reactivedb Spec', () => {
   describe('ReactiveDB async load in', () => {
 
     it('getMyRecent should response correct data when reactivedb async load in', done => {
-      mockResponse(myRecent)
+      mockResponse(myFixture.myRecent)
 
       const token = sdk.getMyRecent(userId, {
         dueDate: '2017-02-13T03:38:54.252Z',
@@ -101,7 +101,7 @@ describe('Async load reactivedb Spec', () => {
             return new Date(x.updated).valueOf() - new Date(y.updated).valueOf()
               + new Date(x.created).valueOf() - new Date(y.created).valueOf()
           }
-          const expected = myRecent.sort(compareFn)
+          const expected = myFixture.norm(myFixture.myRecent).sort(compareFn)
           const actual = r.map(_r => {
             if (_r.type === 'task') {
               if (!(_r as TaskSchema).recurrence) {
@@ -114,9 +114,7 @@ describe('Async load reactivedb Spec', () => {
               }
             }
             if (_r instanceof EventGenerator) {
-              const dist = _r.next().value
-              dist._id = dist._sourceId
-              return dist
+              return _r.next().value
             }
             return _r
           })


### PR DESCRIPTION
之前的 next 方法第一次拿 startDate 没有经过 rrule.after 检查，导致及时第一个 startDate 不在 rruleset 所可能的实例中，也会被 next 生成出来。