### PR TITLE
refactor(EventGenerator): 令 next() 遵从 iterator protocol

### DIFF
--- a/src/apis/event/EventGenerator.ts
+++ b/src/apis/event/EventGenerator.ts
@@ -5,103 +5,188 @@ import { EventId } from 'teambition-types'
 
 const { rrulestr } = require('rrule')
 
-export class EventGenerator implements IterableIterator<EventSchema> {
+type TimeFrame = { startDate: Date, endDate: Date }
+
+export class EventGenerator implements IterableIterator<EventSchema | undefined> {
   type: 'event' = 'event'
   _id: EventId
 
+  private done: boolean
   private rrule: any
   private startDate: Date
   private isRecurrence = isRecurrence(this.event)
-  private interval: number
+  private duration: number
 
   [Symbol.iterator] = () => this
 
   constructor(private event: EventSchema) {
     this._id = event._id
+    this.done = false
+
+    const startDateObj = new Date(event.startDate)
+    const endDateObj = new Date(event.endDate)
+    this.duration = endDateObj.valueOf() - startDateObj.valueOf()
+
     if (this.isRecurrence) {
-      const startDateObj = new Date(event.startDate)
-      const endDateObj = new Date(event.endDate)
-      this.interval = endDateObj.valueOf() - startDateObj.valueOf()
       this.startDate = startDateObj
       this.rrule = rrulestr(this.event.recurrence.join('\n'), { forceset: true })
     }
   }
 
-  next(): IteratorResult<EventSchema> {
-    if (!this.isRecurrence) {
-      return { value: clone(this.event), done: true }
-    }
+  // 从给予的 startDate 和 endDate 生成一个 EventSchema 对象；
+  // 当用于普通日程，不需要提供参数。
+  private makeEvent(timeFrame?: TimeFrame): EventSchema {
     const target = clone(this.event)
-    const startDate = this.rrule.after(this.startDate, true)
-    const startDateVal = startDate.valueOf()
-    const endDate = new Date(startDateVal + this.interval)
-    const afterDate = this.rrule.after(endDate, true)
-    target._id = `${target._id}_${startDateVal}`
-    target.startDate = startDate.toISOString()
-    target.endDate = endDate.toISOString()
-    const result = {
-      done: !afterDate,
-      value: target
+
+    if (!this.isRecurrence || !timeFrame) {
+      return target
     }
-    this.startDate = afterDate
-    return result
+    // this.isRecurrence && timeFrame
+
+    const timestamp = timeFrame.startDate.valueOf()
+    target._id = `${target._id}_${timestamp}`
+    target.startDate = timeFrame.startDate.toISOString()
+    target.endDate = timeFrame.endDate.toISOString()
+
+    return target
   }
 
-  takeUntil(endDate: Date) {
+  private computeEndDate(startDate: Date): Date {
+    return new Date(startDate.valueOf() + this.duration)
+  }
+
+  private slice(
+    from: Date, fromCmpOption: 'byStartDate' | 'byEndDate',
+    to: Date, toCmpOption: 'byStartDate' | 'byEndDate'
+  ): TimeFrame[] {
+    let startDate = new Date(this.event.startDate)
+    let endDate = new Date(this.event.endDate)
+    let eventSpan = { startDate, endDate }
+
+    const skipPred = (eSpan: TimeFrame): boolean =>
+      fromCmpOption === 'byStartDate' && eSpan.startDate < from
+      || fromCmpOption === 'byEndDate' && eSpan.endDate < from
+
+    const stopPred = (eSpan: TimeFrame): boolean =>
+      toCmpOption === 'byStartDate' && eSpan.startDate > to
+      || toCmpOption === 'byEndDate' && eSpan.endDate > to
+
+    const result: TimeFrame[] = []
+
     if (!this.isRecurrence) {
-      return [ clone(this.event) ]
+      if (!skipPred(eventSpan) && !stopPred(eventSpan)) {
+        // eventSpan 在时间范围内
+        result.push({ startDate, endDate })
+      }
+      return result
     }
-    const result: EventSchema[] = []
-    let s = new Date(this.event.startDate)
-    let sv = s.valueOf()
-    let e = new Date(this.event.endDate)
-    while (sv < endDate.valueOf()) {
-      const r = clone(this.event)
-      r._id = `${ r._id }_${ sv }`
-      r.startDate = s.toISOString()
-      r.endDate = e.toISOString()
-      result.push(r)
-      s = this.rrule.after(s)
-      if (!s) {
+
+    for (; startDate; startDate = this.rrule.after(startDate)) {
+      endDate = this.computeEndDate(startDate)
+      eventSpan = { startDate, endDate }
+      if (stopPred(eventSpan)) { // 优先检查停止条件
         break
       }
-      sv = s.valueOf()
-      e = new Date(sv + this.interval)
+      if (skipPred(eventSpan)) { // 其次检查忽略条件
+        continue
+      }
+      // eventSpan 在时间范围内
+      result.push(eventSpan)
     }
     return result
   }
 
-  takeFrom(startDate: Date, endDate: Date) {
+  next(): IteratorResult<EventSchema | undefined> {
+    const doneRet = { value: undefined, done: true }
+
     if (!this.isRecurrence) {
-      if (
-        (new Date(this.event.startDate).valueOf() < endDate.valueOf()) &&
-        (new Date(this.event.endDate).valueOf() > startDate.valueOf())
-      ) {
-        return [ clone(this.event) ]
+      if (this.done) {
+        return doneRet
       } else {
-        return []
+        this.done = true
+        return { value: this.makeEvent(), done: false }
       }
     }
-    let s = this.rrule.after(startDate)
-    if (!s) {
-      return []
+
+    if (!this.startDate) {
+      return doneRet
     }
-    let sv = s.valueOf()
-    let e = new Date(sv + this.interval)
-    const result: EventSchema[] = []
-    while (sv < endDate.valueOf()) {
-      const r = clone(this.event)
-      r._id = `${ r._id }_${ sv }`
-      r.startDate = s.toISOString()
-      r.endDate = e.toISOString()
-      result.push(r)
-      s = this.rrule.after(s)
-      if (!s) {
-        break
-      }
-      sv = s.valueOf()
-      e = new Date(sv + this.interval)
+    // 不直接将 this.startDate 赋给 startDate 的原因是：
+    //   如果这是第一次 next() 调用，this.startDate 未经 after 过滤，
+    //   有可能是一个 exdate（被 rruleset 剔除的日期），发现时需要跳过。
+    const startDate = this.rrule.after(this.startDate, true)
+    const endDate = this.computeEndDate(startDate)
+    const result = {
+      value: this.makeEvent({ startDate, endDate }),
+      done: false
     }
+    this.startDate = this.rrule.after(startDate)
     return result
+  }
+
+  takeUntil(startDateUntil: Date, endDateUntil?: Date) {
+    return this.takeFrom(
+      new Date(this.event.startDate),
+      startDateUntil,
+      endDateUntil
+    )
+  }
+
+  takeFrom(fromDate: Date, startDateTo: Date, endDateTo?: Date) {
+    const toDate = !endDateTo ? startDateTo : new Date(
+      Math.min(
+        startDateTo.valueOf(),
+        endDateTo.valueOf() - this.duration
+      )
+    )
+    return this.slice(
+      fromDate, 'byEndDate',
+      toDate, 'byStartDate'
+    ).map((eventSpan) => this.makeEvent(eventSpan))
+  }
+
+  after(date: Date) {
+    if (!this.isRecurrence) {
+      if (new Date(this.event.startDate) < date) {
+        return undefined
+      } else {
+        return this.event
+      }
+    }
+    const startDate = this.rrule.after(date, true)
+    if (!startDate) {
+      return undefined
+    }
+    const endDate = this.computeEndDate(startDate)
+    return this.makeEvent({ startDate, endDate })
+  }
+
+  findByEventId(eventId: EventId): EventSchema | undefined {
+    if (!this.isRecurrence) {
+      return eventId === this.event._id ? this.makeEvent() : undefined
+    }
+
+    const [id, timestampStr] = eventId.split('_', 2)
+    if (id !== this.event._id) {
+      return undefined
+    }
+
+    // 不使用 parseInt 因为不应该兼容前缀正确的错误 timestamp
+    const timestamp = Number(timestampStr)
+    const expectedDate = new Date(timestamp)
+    if (isNaN(timestamp) || isNaN(expectedDate.valueOf())) {
+      return undefined
+    }
+    // expectedDate is a valid Date object
+
+    const actualDate: Date = this.rrule.after(expectedDate, true)
+    if (!actualDate || actualDate.valueOf() !== expectedDate.valueOf()) {
+      return undefined
+    }
+
+    return this.makeEvent({
+      startDate: expectedDate,
+      endDate: this.computeEndDate(expectedDate)
+    })
   }
 }


### PR DESCRIPTION
原来的 next() 函数在生成最后一个合法 value 时同时返回 done: true，这与 [iterator protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) 不同，并且会导致用户程序需要使用 do...while 循环体，容易出错。修改后的 next() 在生成最后一个合法 value 之后，下一次调用时才返回 done: true。

...并更精确地定义 takeFrom 和 takeUntil 的边界行为：

 - takeFrom 在开始处会包含 startDate 不在区间内的未结束日程，在终结处会包含 endDate 不在区间内但已经开始的日程，并且可以额外添加一个针对 endDate 的截止时间作为第三个参数；

 - takeUntil 如 takeFrom.bind(this, new Date(this.event.startDate))。

...并添加 after 接口

上面三个接口皆能同时在普通日程和重复日程上工作。