### PR TITLE
refactor(Net/Http, SDKFetch): 为 Net/Http 添加 clone 方法

### DIFF
--- a/mock/mock.ts
+++ b/mock/mock.ts
@@ -95,7 +95,7 @@ export function mockFetch() {
       } else {
         result = results[0]
       }
-      // console.info(uri + method + dataPath, fetchStack)
+
       const wait = result.wait
       if (!wait || wait < 0) {
         return Promise.resolve(new Response(result.response.data, result.response.responseInit))

--- a/src/Net/Http.ts
+++ b/src/Net/Http.ts
@@ -5,7 +5,7 @@ import { AjaxError } from 'rxjs/observable/dom/AjaxObservable'
 import { Observable } from 'rxjs/Observable'
 import { Observer } from 'rxjs/Observer'
 import { Subject } from 'rxjs/Subject'
-import { forEach, parseHeaders, headers2Object } from '../utils/index'
+import { parseHeaders, headers2Object } from '../utils/index'
 import { testable } from '../testable'
 
 export type AllowedHttpMethod = 'get' | 'post' | 'put' | 'delete'
@@ -21,10 +21,11 @@ export const HttpError$: Observable<HttpErrorMessage> = new Subject<HttpErrorMes
 
 export class Http<T> {
   private errorAdapter$: Subject<HttpErrorMessage>
-  public request: () => Observable<T>
+  private cloned = false
+  private request: Observable<T>
   public mapFn: <U>(stream$: Observable<T>) => Observable<U> = (dist$: Observable<T>) => dist$
 
-  constructor(errorAdapter$?: Subject<HttpErrorMessage>) {
+  constructor(private url: string, errorAdapter$?: Subject<HttpErrorMessage>) {
     if (errorAdapter$) {
       this.errorAdapter$ = errorAdapter$
     } else {
@@ -40,20 +41,9 @@ export class Http<T> {
     credentials: 'include'
   }
 
-  private _apiHost = 'https://www.teambition.com/api'
-
   public map<U>(fn: (stream$: Observable<T>) => Observable<U>) {
     this.mapFn = fn
     return this as any as Http<U>
-  }
-
-  public getAPIHost(): string {
-    return this._apiHost
-  }
-
-  public setAPIHost(host: string) {
-    this._apiHost = host
-    return this
   }
 
   public setHeaders(headers: any) {
@@ -83,140 +73,120 @@ export class Http<T> {
     return this
   }
 
-  public get(url: string, query?: any) {
-    const uri = this._buildQuery(url, query)
-    this.request = this.createMethod('get')(uri)
+  public get() {
+    this.request = this.createMethod('get')(this.url)
     return this
   }
 
-  public post(url: string, body?: any) {
-    this.request = this.createMethod('post')(url, body)
+  public post(body?: any) {
+    this.request = this.createMethod('post')(this.url, body)
     return this
   }
 
-  public put(url: string, body?: any) {
-    this.request = this.createMethod('put')(url, body)
+  public put(body?: any) {
+    this.request = this.createMethod('put')(this.url, body)
     return this
   }
 
-  public delete(url: string) {
-    this.request = this.createMethod('delete')(url)
+  public delete() {
+    this.request = this.createMethod('delete')(this.url)
     return this
   }
 
   public send(): Observable<T> {
-    return this.mapFn(this.request())
+    return this.mapFn(this.request)
   }
 
-  public _buildQuery(url: string, query: any) {
-    if (typeof query !== 'object' || !query) {
-      return url
+  public clone() {
+    const result = new Http<T>(this.url, this.errorAdapter$)
+    if (!this.cloned && this.request) {
+      this.request = this.request.publishReplay(1).refCount()
+      this.cloned = true
+      result.cloned = true
     }
-    const result: string[] = []
-    forEach(query, (val: any, key: string) => {
-      if (Array.isArray(val)) {
-        (<any[]>val).forEach(_val => {
-          if (typeof _val !== 'undefined') {
-            result.push(`${key}=${_val}`)
-          }
+    result.request = this.request
+    return result
+  }
+
+  public createMethod(method: AllowedHttpMethod): (url: string, body?: any) => Observable<T> {
+    return (url: string, body?: any) => {
+      /* istanbul ignore if */
+      if (testable.UseXMLHTTPRequest && typeof window !== 'undefined') {
+        return Observable.ajax({
+          url, body, method,
+          headers: this._opts.headers,
+          withCredentials: this._opts.credentials === 'include',
+          responseType: this._opts.responseType || 'json',
+          crossDomain: typeof this._opts.crossDomain !== 'undefined' ? !!this._opts.crossDomain : true
         })
-      } else {
-        if (typeof val !== 'undefined') {
-          result.push(`${key}=${val}`)
-        }
-      }
-    })
-    let _query: string
-    if (url.indexOf('?') !== -1) {
-      _query = result.length ? '&' + result.join('&') : ''
-    } else {
-      _query = result.length ? '?' + result.join('&') : ''
-    }
-    return url + _query
-  }
-
-  public createMethod(method: AllowedHttpMethod): (path: string, body?: any) => () => Observable<T> {
-    return (path: string, body?: any) => {
-      return () => {
-        const url = `${this._apiHost}/${path}`
-        /* istanbul ignore if */
-        if (testable.UseXMLHTTPRequest && typeof window !== 'undefined') {
-          return Observable.ajax({
-            url, body, method,
-            headers: this._opts.headers,
-            withCredentials: this._opts.credentials === 'include',
-            responseType: this._opts.responseType || 'json',
-            crossDomain: typeof this._opts.crossDomain !== 'undefined' ? !!this._opts.crossDomain : true
+          .map(value => {
+            const resp = value.response
+            const headers = value.xhr.getAllResponseHeaders()
+            try {
+              const result = JSON.parse(resp)
+              const requestId = parseHeaders(headers)['x-request-id']
+              return requestId ? { ...result, requestId } : result
+            } catch (e) {
+              return resp
+            }
           })
-            .map(value => {
-              const resp = value.response
-              const headers = value.xhr.getAllResponseHeaders()
-              try {
-                const result = JSON.parse(resp)
-                const requestId = parseHeaders(headers)['x-request-id']
-                return requestId ? { ...result, requestId } : result
-              } catch (e) {
-                return resp
+          .catch((e: AjaxError) => {
+            const headers = e.xhr.getAllResponseHeaders()
+            const sdkError: HttpErrorMessage = {
+              error: new Response(new Blob([JSON.stringify(e.xhr.response)]), {
+                status: e.xhr.status,
+                statusText: e.xhr.statusText,
+                headers: headers.length ? new Headers(parseHeaders(headers)) : new Headers()
+              }),
+              method, url, body
+            }
+
+            setTimeout(() => {
+              this.errorAdapter$.next(sdkError)
+            }, 10)
+            return Observable.throw(sdkError)
+          })
+      } else {
+        return Observable.create((observer: Observer<any>) => {
+          const _options = {
+            ... this._opts,
+            method: method
+          }
+          if (body) {
+            _options.body = typeof body === 'object' ? JSON.stringify(body) : body
+          }
+          let headers: Headers
+          fetch(url, _options)
+            .then((response: Response): Promise<string> => {
+              if (response.status >= 200 && response.status < 400) {
+                headers = response.headers
+                return response.text()
+              } else {
+                throw response
               }
             })
-            .catch((e: AjaxError) => {
-              const headers = e.xhr.getAllResponseHeaders()
+            .then(r => {
+              try {
+                const result = JSON.parse(r)
+                const requestId = headers2Object(headers)['x-request-id']
+                observer.next(requestId ? { ...result, requestId } : result)
+              } catch (e) {
+                observer.next(r)
+              }
+              observer.complete()
+            })
+            .catch((e: Response) => {
               const sdkError: HttpErrorMessage = {
-                error: new Response(new Blob([JSON.stringify(e.xhr.response)]), {
-                  status: e.xhr.status,
-                  statusText: e.xhr.statusText,
-                  headers: headers.length ? new Headers(parseHeaders(headers)) : new Headers()
-                }),
+                error: e,
                 method, url, body
               }
 
               setTimeout(() => {
                 this.errorAdapter$.next(sdkError)
               }, 10)
-              return Observable.throw(sdkError)
+              observer.error(sdkError)
             })
-        } else {
-          return Observable.create((observer: Observer<any>) => {
-            const _options = {
-              ... this._opts,
-              method: method
-            }
-            if (body) {
-              _options.body = typeof body === 'object' ? JSON.stringify(body) : body
-            }
-            let headers: Headers
-            fetch(url, _options)
-              .then((response: Response): Promise<string> => {
-                if (response.status >= 200 && response.status < 400) {
-                  headers = response.headers
-                  return response.text()
-                } else {
-                  throw response
-                }
-              })
-              .then(r => {
-                try {
-                  const result = JSON.parse(r)
-                  const requestId = headers2Object(headers)['x-request-id']
-                  observer.next(requestId ? { ...result, requestId } : result)
-                } catch (e) {
-                  observer.next(r)
-                }
-                observer.complete()
-              })
-              .catch((e: Response) => {
-                const sdkError: HttpErrorMessage = {
-                  error: e,
-                  method, url, body
-                }
-
-                setTimeout(() => {
-                  this.errorAdapter$.next(sdkError)
-                }, 10)
-                observer.error(sdkError)
-              })
-          })
-        }
+        })
       }
     }
   }

--- a/src/SDKFetch.ts
+++ b/src/SDKFetch.ts
@@ -6,53 +6,125 @@ import 'rxjs/add/operator/finally'
 import { Observable } from 'rxjs/Observable'
 import { Http } from './Net/Http'
 import { UserMe } from './schemas/UserMe'
+import { forEach } from './utils/index'
 
 export class SDKFetch {
 
-  static FetchStack = new Map<string, () => Observable<any>>()
+  constructor(
+    private apiHost: string = 'https://www.teambition.com/api',
+    private token: string = '',
+    private headers = {},
+    private options = {}
+  ) {}
+
+  static FetchStack = new Map<string, Observable<any>>()
   static fetchTail: string | undefined | 0
 
-  // @override
-  get<T>(url: string, query?: any) {
-    const http = new Http<T>()
-    const tail = SDKFetch.fetchTail || Date.now()
-    const uri = http._buildQuery(url, query)
-    let _uri: string
-    if (SDKFetch.FetchStack.has(uri)) {
-      http.request = SDKFetch.FetchStack.get(uri)!
+  get<T>(path: string, query?: any) {
+    const url = this.urlWithPath(path)
+    const urlWithQuery = query ? this._buildQuery(url, query) : url
+    const http = this.setOpts(new Http<T>(urlWithQuery))
+
+    if (SDKFetch.FetchStack.has(urlWithQuery)) {
+      // re-use connection when available
+      http['request'] = SDKFetch.FetchStack.get(urlWithQuery)!
       return http
     }
-    if (query) {
-      _uri = `${uri}&_=${ tail }`
-    } else {
-      _uri = `${uri}?_=${ tail }`
-    }
-    const dist = Observable.defer(() => http.createMethod('get')(_uri)()
+
+    const tail = SDKFetch.fetchTail || Date.now()
+    const urlWithTail = query
+      ? `${ urlWithQuery }&_=${ tail }`
+      : `${ urlWithQuery }?_=${ tail }`
+    const dist = Observable.defer(() => http.createMethod('get')(urlWithTail)
       .publishReplay(1)
       .refCount()
     )
       .finally(() => {
-        SDKFetch.FetchStack.delete(uri)
+        SDKFetch.FetchStack.delete(urlWithQuery)
       })
 
-    SDKFetch.FetchStack.set(uri, () => dist)
-    http.request = () => dist
+    SDKFetch.FetchStack.set(urlWithQuery, dist)
+    http['request'] = dist
     return http
   }
 
-  public post<T>(url: string, body?: any) {
-    const http = new Http<T>()
-    return http.post(url, body)
+  private urlWithPath(path: string): string {
+    return `${this.apiHost}/${path}`
   }
 
-  public put<T>(url: string, body?: any) {
-    const http = new Http<T>()
-    return http.put(url, body)
+  public post<T>(path: string, body?: any) {
+    const http = this.setOpts<T>(new Http<T>(this.urlWithPath(path)))
+    return http.post(body)
   }
 
-  public delete<T>(url: string) {
-    const http = new Http<T>()
-    return http.delete(url)
+  public put<T>(path: string, body?: any) {
+    const http = this.setOpts<T>(new Http<T>(this.urlWithPath(path)))
+    return http.put(body)
+  }
+
+  public delete<T>(path: string) {
+    const http = this.setOpts<T>(new Http<T>(this.urlWithPath(path)))
+    return http.delete()
+  }
+
+  public setAPIHost(host: string) {
+    this.apiHost = host
+  }
+
+  public getAPIHost() {
+    return this.apiHost
+  }
+
+  public setHeaders(headers: {}) {
+    this.headers = headers
+  }
+
+  public setToken(token: string) {
+    this.token = token
+  }
+
+  public setOptions(options: {}) {
+    this.options = options
+  }
+
+  private setOpts<T>(http: Http<T>) {
+    if (Object.keys(this.headers).length > 0) {
+      http.setHeaders(this.headers)
+    }
+    if (this.token) {
+      http.setToken(this.token)
+    }
+    if (Object.keys(this.options).length > 0) {
+      http.setOpts(this.options)
+    }
+    return http
+  }
+
+  private _buildQuery(url: string, query: any) {
+    if (typeof query !== 'object' || !query) {
+      return url
+    }
+    const result: string[] = []
+    forEach(query, (val: any, key: string) => {
+      if (Array.isArray(val)) {
+        (<any[]>val).forEach(_val => {
+          if (typeof _val !== 'undefined') {
+            result.push(`${key}=${_val}`)
+          }
+        })
+      } else {
+        if (typeof val !== 'undefined') {
+          result.push(`${key}=${val}`)
+        }
+      }
+    })
+    let _query: string
+    if (url.indexOf('?') !== -1) {
+      _query = result.length ? '&' + result.join('&') : ''
+    } else {
+      _query = result.length ? '?' + result.join('&') : ''
+    }
+    return url + _query
   }
 
   getUserMe() {

--- a/src/fetchs/SocketFetch.ts
+++ b/src/fetchs/SocketFetch.ts
@@ -5,7 +5,7 @@ export class SocketFetch extends SDKFetch {
     return this.post<void>(`${room}/subscribe`, {
       consumerId: consumerId
     })
-    .send<void>()
+    .send()
     .toPromise()
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,6 @@ export * from './schemas'
 
 export { SDK } from './SDK'
 export { SDKFetch } from './SDKFetch'
-export { Net, CacheStrategy, Http, HttpErrorMessage } from './Net'
+export { Net, CacheStrategy, Http, HttpErrorMessage, HttpError$ } from './Net'
 
 // export const SocketClient: Client = sdk.socket

--- a/test/SDKFetch.spec.ts
+++ b/test/SDKFetch.spec.ts
@@ -1,0 +1,141 @@
+import { expect } from 'chai'
+import { Scheduler } from 'rxjs'
+import { describe, it, beforeEach } from 'tman'
+import { SDKFetch, forEach } from '.'
+
+const fetchMock = require('fetch-mock')
+
+export default describe('SDKFetch', () => {
+
+  let sdkFetch: SDKFetch
+  const apiHost = 'https://www.teambition.com/api'
+  const path = 'test'
+  const testUrl = `${apiHost}/${path}`
+
+  beforeEach(() => {
+    sdkFetch = new SDKFetch()
+  })
+
+  it('setAPIHost/getAPIHost should configure api host', () => {
+    expect(sdkFetch.getAPIHost()).to.equal('https://www.teambition.com/api')
+    const myUrl = 'https://www.example.com'
+    sdkFetch.setAPIHost(myUrl)
+    expect(sdkFetch.getAPIHost()).to.equal(myUrl)
+  })
+
+  it('setHeaders should work', function* () {
+    const headers = { 'X-Request-Id': '2333' }
+    sdkFetch.setHeaders(headers)
+    fetchMock.mock(new RegExp(testUrl), {})
+    yield sdkFetch.get(path)
+      .send()
+      .subscribeOn(Scheduler.async)
+      .do(() => {
+        expect(fetchMock.lastOptions()).to.deep.equal({
+          method: 'get',
+          headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'X-Request-Id': '2333'
+          },
+          credentials: 'include'
+        })
+        fetchMock.restore()
+      })
+  })
+
+  it('setToken should work', function* () {
+    const token = 'secret, public :)'
+    sdkFetch.setToken(token)
+    fetchMock.getOnce(new RegExp(testUrl), {})
+    yield sdkFetch.get(path)
+      .send()
+      .subscribeOn(Scheduler.async)
+      .do(() => {
+        expect(fetchMock.lastOptions()).to.deep.equal({
+          method: 'get',
+          headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'Authorization': `OAuth2 ${token}`
+          }
+        })
+        fetchMock.restore()
+      })
+  })
+
+  it('get should use correctly timestamped url', function* () {
+    const urlMatcher = new RegExp(testUrl)
+    fetchMock.get(urlMatcher, {})
+
+    // 无 query 的 GET
+    yield sdkFetch.get(path)
+      .send()
+      .subscribeOn(Scheduler.async)
+      .do(() => {
+        const delimiter = '?_='
+        const [prefix, timestamp] = fetchMock.lastUrl(urlMatcher).split(delimiter, 2)
+        expect(prefix).to.equal(testUrl)
+        expect(new Date(Number(timestamp)).valueOf()).to.closeTo(new Date().valueOf(), 100)
+      })
+
+    // 带 query 的 GET
+    const query = { value: 'A' }
+    const urlWithQuery = testUrl + '?value=A'
+    yield sdkFetch.get(path, query)
+      .send()
+      .subscribeOn(Scheduler.async)
+      .do(() => {
+        const delimiter = '&_='
+        const [prefix, timestamp] = fetchMock.lastUrl(urlMatcher).split(delimiter, 2)
+        expect(prefix).to.equal(urlWithQuery)
+        expect(new Date(Number(timestamp)).valueOf()).to.closeTo(new Date().valueOf(), 100)
+        fetchMock.restore()
+      })
+  })
+
+  it('get should re-use observable for mathcing request', () => {
+    const getA = sdkFetch.get(path, { value: 'A' })
+    const anotherGetA = sdkFetch.get(path, { value: 'A' })
+    const getB = sdkFetch.get(path, { value: 'B' })
+
+    // 确定目标值不是 undefined
+    expect(getA['request']).not.undefined
+    expect(anotherGetA['request']).not.undefined
+    expect(getB['request']).not.undefined
+
+    // anotherGetA 应该重用 getA 里的 request observable
+    expect(anotherGetA['request']).equal(getA['request'])
+
+    // getB 应该使用自己的 request observable
+    expect(getB['request']).not.equal(getA['request'])
+  })
+
+  it('_buildQuery should serialize array to query string', () => {
+    const query = { a: 'a', b: [1, 2, 'b', 'b'], c: 3 }
+    const parts: string[] = []
+    forEach(query, (value, key) => {
+      if (!Array.isArray(value)) {
+        value = <any>[value]
+      }
+      parts.push(...(<any[]>value).map(v => `${key}=${v}`))
+    })
+    const actual = sdkFetch['_buildQuery']('', query)
+    const expected = `?${parts.join('&')}`
+    expect(actual).to.be.equal(expected)
+  })
+
+  it('_buildQuery should serialize query with queryUrl to query string', () => {
+    const query = { a: 'a', b: [1, 2, 'b', 'b'], c: 3 }
+    const parts: string[] = []
+    forEach(query, (value, key) => {
+      if (!Array.isArray(value)) {
+        value = <any>[value]
+      }
+      parts.push(...(<any[]>value).map(v => `${key}=${v}`))
+    })
+    const actual = sdkFetch['_buildQuery']('http://abc.com?_=123', query)
+    const expected = `http://abc.com?_=123&${parts.join('&')}`
+    expect(actual).to.be.equal(expected)
+  })
+})

--- a/test/index.ts
+++ b/test/index.ts
@@ -3,6 +3,8 @@ import { Database, DataStoreType } from 'reactivedb'
 import { testable } from '../src/testable'
 import { SDK } from '../src/index'
 
+import './SDKFetch.spec'
+
 testable.UseXMLHTTPRequest = false
 
 export function createSdk() {

--- a/test/mock/MockFetch.ts
+++ b/test/mock/MockFetch.ts
@@ -1,4 +1,4 @@
-import { Backend, SDKFetch, Http } from '../index'
+import { Backend, SDKFetch } from '../index'
 
 function throwIfSlashPath(path: string) {
   if (path.charAt(0) === '/') {
@@ -8,12 +8,12 @@ function throwIfSlashPath(path: string) {
 
 export class MockFetch extends SDKFetch {
   private httpBackend = new Backend
-  private apiHost = new Http<any>().getAPIHost()
+  private _apiHost = new SDKFetch().getAPIHost()
 
   mockGet(path: string, query?: any) {
     throwIfSlashPath(path)
     return {
-      mockResponse: this.httpBackend.whenGET(`${this.apiHost}/${path}`, query),
+      mockResponse: this.httpBackend.whenGET(`${this._apiHost}/${path}`, query),
       request: this.get(path, query)
     }
   }
@@ -21,7 +21,7 @@ export class MockFetch extends SDKFetch {
   mockPut(path: string, body?: any) {
     throwIfSlashPath(path)
     return {
-      mockResponse: this.httpBackend.whenPUT(`${this.apiHost}/${path}`, body),
+      mockResponse: this.httpBackend.whenPUT(`${this._apiHost}/${path}`, body),
       request: this.put(path, body)
     }
   }
@@ -29,7 +29,7 @@ export class MockFetch extends SDKFetch {
   mockPost(path: string, body?: any) {
     throwIfSlashPath(path)
     return {
-      mockResponse: this.httpBackend.whenPOST(`${this.apiHost}/${path}`, body),
+      mockResponse: this.httpBackend.whenPOST(`${this._apiHost}/${path}`, body),
       request: this.post(path, body)
     }
   }
@@ -37,7 +37,7 @@ export class MockFetch extends SDKFetch {
   mockDelete(path: string) {
     throwIfSlashPath(path)
     return {
-      mockResponse: this.httpBackend.whenDELETE(`${this.apiHost}/${path}`),
+      mockResponse: this.httpBackend.whenDELETE(`${this._apiHost}/${path}`),
       request: this.delete(path)
     }
   }

--- a/test/net/net.ts
+++ b/test/net/net.ts
@@ -18,8 +18,9 @@ describe('Net test', () => {
   let version = 1
   let subscription: Subscription | undefined
   const sdkFetch = new SDKFetch()
-  const http = new Http
-  const apiHost = http.getAPIHost()
+  const apiHost = sdkFetch.getAPIHost()
+  const path = 'test'
+  const http = new Http(`${apiHost}/${path}`)
   beforeEach(() => {
     httpBackend = new Backend()
     net = new Net(schemas)
@@ -41,12 +42,11 @@ describe('Net test', () => {
 
   describe('Net#handleApiResult', () => {
     it('should handle Object type response and consumed by `values`', function* () {
-      httpBackend.whenGET(`${apiHost}/api/test`)
+      httpBackend.whenGET(`${apiHost}/${path}`)
         .respond(normalEvent)
-
       yield net.lift({
         cacheValidate: CacheStrategy.Cache,
-        request: sdkFetch.get('api/test'),
+        request: sdkFetch.get(path),
         query: {
           where: { _id: normalEvent._id },
         },
@@ -63,12 +63,12 @@ describe('Net test', () => {
     })
 
     it('should handle Object type response and consumed by `changes`', function* () {
-      httpBackend.whenGET(`${apiHost}/api/test`)
+      httpBackend.whenGET(`${apiHost}/${path}`)
         .respond(normalEvent)
 
       yield net.lift({
         cacheValidate: CacheStrategy.Cache,
-        request: sdkFetch.get('api/test'),
+        request: sdkFetch.get(path),
         query: {
           where: { _id: normalEvent._id },
         },
@@ -86,12 +86,12 @@ describe('Net test', () => {
     })
 
     it('should handle Object type response and get changes', function* () {
-      httpBackend.whenGET(`${apiHost}/api/test`)
+      httpBackend.whenGET(`${apiHost}/${path}`)
         .respond(normalEvent)
 
       const stream$ = net.lift<typeof normalEvent>({
         cacheValidate: CacheStrategy.Cache,
-        request: sdkFetch.get<any>('api/test'),
+        request: sdkFetch.get<any>(path),
         query: {
           where: { _id: normalEvent._id },
         },
@@ -125,12 +125,12 @@ describe('Net test', () => {
     })
 
     it('should handle Array type response and consumed by `values`', function* () {
-      httpBackend.whenGET(`${apiHost}/api/test`)
+      httpBackend.whenGET(`${apiHost}/${path}`)
         .respond(projectEvents)
 
       yield net.lift({
         cacheValidate: CacheStrategy.Request,
-        request: sdkFetch.get('api/test'),
+        request: sdkFetch.get(path),
         query: {
           where: { _projectId: projectEvents[0]._projectId },
         },
@@ -147,12 +147,12 @@ describe('Net test', () => {
     })
 
     it('should handle Array type response and consumed by `changes`', function* () {
-      httpBackend.whenGET(`${apiHost}/api/test`)
+      httpBackend.whenGET(`${apiHost}/${path}`)
         .respond(projectEvents)
 
       yield net.lift({
         cacheValidate: CacheStrategy.Request,
-        request: sdkFetch.get('api/test'),
+        request: sdkFetch.get(path),
         query: {
           where: { _projectId: projectEvents[0]._projectId },
         },
@@ -170,12 +170,12 @@ describe('Net test', () => {
     })
 
     it('should handle Array type response and get changes', function* () {
-      httpBackend.whenGET(`${apiHost}/api/test`)
+      httpBackend.whenGET(`${apiHost}/${path}`)
         .respond(projectEvents)
 
       const stream$ = net.lift({
         cacheValidate: CacheStrategy.Request,
-        request: sdkFetch.get('api/test'),
+        request: sdkFetch.get(path),
         query: {
           where: { _projectId: projectEvents[0]._projectId },
         },
@@ -208,7 +208,7 @@ describe('Net test', () => {
     })
 
     it('should handle Array type response and validate cache', function* () {
-      httpBackend.whenGET(`${apiHost}/api/test`)
+      httpBackend.whenGET(`${apiHost}/${path}`)
         .respond(projectEvents)
 
       const spyFetch = spy(sdkFetch, 'get')
@@ -223,7 +223,7 @@ describe('Net test', () => {
 
       const stream$ = net.lift<any>({
         cacheValidate: CacheStrategy.Request,
-        request: sdkFetch.get<any>('api/test'),
+        request: sdkFetch.get<any>(path),
         query: {
           where: { _projectId: projectEvents[0]._projectId },
         },
@@ -260,7 +260,7 @@ describe('Net test', () => {
     })
 
     it('should handle empty Array', function* () {
-      httpBackend.whenGET(`${apiHost}/api/test`)
+      httpBackend.whenGET(`${apiHost}/${path}`)
         .respond([])
 
       const spyFetch = spy(sdkFetch, 'get')
@@ -275,7 +275,7 @@ describe('Net test', () => {
 
       const stream$ = net.lift({
         cacheValidate: CacheStrategy.Request,
-        request: sdkFetch.get<any>('api/test'),
+        request: sdkFetch.get<any>(path),
         query: {
           where: { _projectId: projectEvents[0]._projectId },
         },
@@ -312,12 +312,12 @@ describe('Net test', () => {
     })
 
     it('should get result from cached Response and consumed by `values`', function* () {
-      httpBackend.whenGET(`${apiHost}/api/test`)
+      httpBackend.whenGET(`${apiHost}/${path}`)
         .respond(projectEvents)
 
       const getToken = () => net.lift({
         cacheValidate: CacheStrategy.Request,
-        request: sdkFetch.get('api/test'),
+        request: sdkFetch.get(path),
         query: {
           where: { _projectId: projectEvents[0]._projectId },
         },
@@ -342,12 +342,12 @@ describe('Net test', () => {
     })
 
     it('should get result from cached Response and consumed by `changes`', function* () {
-      httpBackend.whenGET(`${apiHost}/api/test`)
+      httpBackend.whenGET(`${apiHost}/${path}`)
         .respond(projectEvents)
 
       const getToken = () => net.lift({
         cacheValidate: CacheStrategy.Request,
-        request: sdkFetch.get('api/test'),
+        request: sdkFetch.get(path),
         query: {
           where: { _projectId: projectEvents[0]._projectId },
         },
@@ -373,12 +373,12 @@ describe('Net test', () => {
     })
 
     it('should get result from cached Response and get changes', function* () {
-      httpBackend.whenGET(`${apiHost}/api/test`)
+      httpBackend.whenGET(`${apiHost}/${path}`)
         .respond(projectEvents)
 
       const getToken = () => net.lift({
         cacheValidate: CacheStrategy.Request,
-        request: sdkFetch.get('api/test'),
+        request: sdkFetch.get(path),
         query: {
           where: { _projectId: projectEvents[0]._projectId },
         },
@@ -419,12 +419,12 @@ describe('Net test', () => {
     })
 
     it('should get result from cached Response and validate cache', function* () {
-      httpBackend.whenGET(`${apiHost}/api/test`)
+      httpBackend.whenGET(`${apiHost}/${path}`)
         .respond(projectEvents)
 
       const getToken = () => net.lift({
         cacheValidate: CacheStrategy.Request,
-        request: sdkFetch.get<any>('api/test'),
+        request: sdkFetch.get<any>(path),
         query: {
           where: { _projectId: projectEvents[0]._projectId },
         },
@@ -486,7 +486,7 @@ describe('Net test', () => {
     it('invalid cacheStrategy should throw', () => {
       const fn = () => net.lift({
         cacheValidate: 2313,
-        request: sdkFetch.get('api/test'),
+        request: sdkFetch.get(path),
         query: {
           where: { _projectId: projectEvents[0]._projectId },
         },
@@ -505,7 +505,7 @@ describe('Net test', () => {
     it('invalid tableName should throw', () => {
       const fn = () => net.lift({
         cacheValidate: CacheStrategy.Request,
-        request: sdkFetch.get('api/test'),
+        request: sdkFetch.get(path),
         query: {
           where: { _projectId: projectEvents[0]._projectId },
         },

--- a/test/utils/httpErrorSpec.ts
+++ b/test/utils/httpErrorSpec.ts
@@ -2,7 +2,7 @@ import * as chai from 'chai'
 import { Subject } from 'rxjs/Subject'
 import { describe, it, beforeEach, afterEach } from 'tman'
 
-import { Http, Backend, HttpErrorMessage } from '../index'
+import { Http, Backend, HttpErrorMessage, SDKFetch } from '../index'
 
 const expect = chai.expect
 
@@ -17,8 +17,8 @@ export default describe('HttpError$ test: ', () => {
   beforeEach(() => {
     error$ = new Subject<HttpErrorMessage>()
     httpBackend = new Backend()
-    mockFetch = new Http(error$)
-    url = `${mockFetch.getAPIHost()}/${path}`
+    url = `${new SDKFetch().getAPIHost()}/${path}`
+    mockFetch = new Http(url, error$)
   })
 
   afterEach(() => {
@@ -40,7 +40,7 @@ export default describe('HttpError$ test: ', () => {
         done()
       })
 
-    mockFetch.get(path).send().subscribe()
+    mockFetch.get().send().subscribe()
   })
 
   it('handler sequence error should ok', done => {
@@ -63,7 +63,7 @@ export default describe('HttpError$ test: ', () => {
         done()
       })
 
-    mockFetch.get(path).send().subscribe()
-    mockFetch.get(path).send().subscribe()
+    mockFetch.get().send().subscribe()
+    mockFetch.get().send().subscribe()
   })
 })


### PR DESCRIPTION
...以支持一个请求的“返回值”要在多个地方做多种转换的场景。

并根据使用中遇到的可用性问题，调整 Net/Http 和 SDKFetch 的接口：

 - 将 Net/Http 视为主要面向 SDK 内部使用的接口，而把 SDKFetch 的接口设
   计为外部用户习惯的形态；
 - Net/Http 中的 get/post/put/delete 方法不再接受 url 或 path 作为参数，
   因为完整的 url 已经在其构造函数中定义；
 - SDKFetch 中的 get/post/put/delete 方法接受 path 参数，以及其他参数，
   每一个调用都会 new 一个对应的 Http 对象，并传入完整 url，及相关参数；
 - SDKFetch 中允许 setHeaders, setToken, setOptions。