### PR TITLE
fix(EventGenerator): 修复内部方法 slice 中一个 edge case

### DIFF
--- a/src/apis/event/EventGenerator.ts
+++ b/src/apis/event/EventGenerator.ts
@@ -59,8 +59,17 @@ export class EventGenerator implements IterableIterator<EventSchema | undefined>
     from: Date, fromCmpOption: 'byStartDate' | 'byEndDate',
     to: Date, toCmpOption: 'byStartDate' | 'byEndDate'
   ): TimeFrame[] {
-    let startDate = new Date(this.event.startDate)
-    let endDate = new Date(this.event.endDate)
+    let startDate: Date
+    let endDate: Date
+
+    if (!this.isRecurrence) {
+      startDate = new Date(this.event.startDate)
+      endDate = new Date(this.event.endDate)
+    } else {
+      startDate = this.rrule.after(this.event.startDate, true)
+      endDate = this.computeEndDate(startDate)
+    }
+
     let eventSpan = { startDate, endDate }
 
     const skipPred = (eSpan: TimeFrame): boolean =>

--- a/test/apis/EventGenerator.spec.ts
+++ b/test/apis/EventGenerator.spec.ts
@@ -212,6 +212,13 @@ describe('EventGenerator spec', () => {
     expect(result).to.deep.equal([])
   })
 
+  it('takeFrom recurrent event that starts at an excluded date should ignore the excluded recurrence', () => {
+    const egen = new EventGenerator(recurrenceStartAtAnExcludedDate as any)
+    const startDate = new Date(recurrenceStartAtAnExcludedDate.startDate)
+    const beforeFirstRecurrence = Moment(startDate).add(1, 'weeks').subtract(1, 'ms').toDate()
+    expect(egen.takeFrom(startDate, beforeFirstRecurrence)).to.deep.equal([])
+  })
+
   it('after should work on a normal event', () => {
     const _eventGenerator = new EventGenerator(normalEvent as any)
     const startDate = new Date(normalEvent.startDate)


### PR DESCRIPTION
...重复日程的 startDate 可能已经被 exclude 掉了，但 slice 依然使用这个
startDate 作为第一个日程实例的开始时间，这是错误的。

之前针对这个问题，在 next() 方法里已经修复过一次。此次在 slice 里复发，
说明这个问题需要有更好的解决办法。再想。