### PR TITLE
fix(create-project): 创建一个全新的项目之后，手动fetch一次members

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,7 @@ cache:
   - node_modules # NPM packages
 
 install:
-  - npm install
-
-before_script:
-  - npm link
-  - npm link teambition-sdk
+  - yarn install
 
 script:
   - "npm run build_all"

--- a/src/apis/ProjectAPI.ts
+++ b/src/apis/ProjectAPI.ts
@@ -15,9 +15,11 @@ import {
 } from '../fetchs/ProjectFetch'
 import ProjectModel from '../models/ProjectModel'
 import HomeActivityModel from '../models/HomeActivityModel'
+import MemberFetch from '../fetchs/MemberFetch'
 import { ProjectData } from '../schemas/Project'
 import { HomeActivityData } from '../schemas/HomeActivity'
 import { makeColdSignal } from './utils'
+
 import {
   CreatedInProjectSchema,
   InviteLinkSchema,
@@ -140,6 +142,7 @@ export class ProjectAPI {
       .concatMap(project =>
         ProjectModel.addOne(project)
           .take(1)
+          .do(() => MemberFetch.getProjectMembers(project._id))
       )
   }
 


### PR DESCRIPTION
- 新建一个项目后，会添加自己为members。后端在创建数据时，会默认将creator添加为involvemember，因此添加用户时候后端认为没有数据变化，所以将会返回一个空数组，所以无法再缓存中lookup到自己。

所以这里的策略是在创建project后，手动fetch一次project member