### PR TITLE
fix(publish): compile err in publish_all and add publish_sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,3 +202,14 @@ export default class TaskView {
 ```
 
 在这种场景下，关于 task 的任何变更 (tasklist 变更，executor 变更，stage 变更等等，权限变化) 都能让相关的数据自动更新，从而简化 View 层的逻辑。
+
+## publish script
+```bash
+# only publish sdk
+npm version xxx
+npm run publish_sdk
+
+# publish sdk, mock and socket
+npm version xxx
+npm run publish_all
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teambition-sdk",
-  "version": "0.8.11-alpha",
+  "version": "0.8.11-alpha.2",
   "description": "Front-End SDK for Teambition",
   "main": "./index.js",
   "typings": "./index.d.ts",
@@ -17,7 +17,8 @@
     "copy_files": "cp README.md package.json ./dist/cjs/",
     "cover": "npm run build_test && rm -rf ./coverage && nyc --reporter=html --reporter=lcov --exclude=node_modules --exclude=spec-js/test --exclude=spec-js/mock --exclude=spec-js/src/sockets/SocketClient.js tman --mocha spec-js/test/app.js",
     "lint": "tslint ./src/**/*.ts ./mock/**/*.ts ./test/*.ts ./test/apis/**/*.ts ./test/mock/**/*.ts ./test/utils/**/*.ts",
-    "publish_all": "npm run build_all && npm run copy_files && npm publish ./dist/cjs && ts-node ./tools/tasks/publish.ts && cp -r ./dist/mock-cjs/** ./.tmp/mock && cp -r ./dist/socket/** ./.tmp/socket && npm publish .tmp/mock/ && npm publish .tmp/socket/",
+    "publish_sdk": "npm run build_all && npm run copy_files && npm publish ./dist/cjs",
+    "publish_all": "npm run publish_sdk && ts-node ./tools/tasks/publish.ts && cp -r ./dist/mock-cjs/** ./.tmp/mock && cp -r ./dist/socket/** ./.tmp/socket && npm publish .tmp/mock/ && npm publish .tmp/socket/",
     "test": "npm run lint && npm run cover",
     "version": "ts-node tools/tasks/version.ts && git add .",
     "watch": "npm run watch_test & ts-node ./tools/tasks/test.ts",

--- a/tools/tasks/publish.ts
+++ b/tools/tasks/publish.ts
@@ -5,12 +5,22 @@ import * as path from 'path'
 const paths = ['mock', 'socket']
 const version = JSON.parse(fs.readFileSync(path.join(process.cwd(), 'package.json'), 'utf8')).version
 
+const mkdirSyncByPath = (pathString: string) => {
+  pathString
+    .split(path.sep)
+    .reduce((curPath: string, folder: string) => {
+      curPath += folder + path.sep
+      if (!fs.existsSync(curPath)) {
+        fs.mkdirSync(curPath)
+      }
+      return curPath
+    }, '')
+}
+
 paths.forEach(_path => {
   const json = JSON.parse(fs.readFileSync(path.join(process.cwd(), `tools/publish/${_path}.json`), 'utf8'))
   json.version = version
-  if (!fs.existsSync(`.tmp/${_path}`)) {
-    fs.mkdirSync(`.tmp/${_path}`)
-  }
+  mkdirSyncByPath(`.tmp/${_path}`)
   fs.writeFileSync(path.join(process.cwd(), `.tmp/${_path}/package.json`), JSON.stringify(json, null, 2), {
     encoding: 'utf8'
   })


### PR DESCRIPTION
- 修复`publish_all`中`ts-node publish.ts`的`node`脚本创建目录错误
- 添加`npm scripts (npm run publish_sdk)` 简化发布流程