### PR TITLE
fix(Http): 修正 Http 对象下 map 方法的类型定义

### DIFF
--- a/src/Net/Http.ts
+++ b/src/Net/Http.ts
@@ -23,7 +23,7 @@ export class Http<T> {
   private errorAdapter$: Subject<HttpErrorMessage>
   private cloned = false
   private request: Observable<T>
-  public mapFn = (dist$: Observable<T>) => dist$
+  public mapFn: (v$: Observable<T>) => Observable<any> = (dist$ => dist$)
 
   constructor(private url: string, errorAdapter$?: Subject<HttpErrorMessage>) {
     if (errorAdapter$) {
@@ -41,7 +41,7 @@ export class Http<T> {
     credentials: 'include'
   }
 
-  public map<U>(fn: <U>(stream$: Observable<T>) => Observable<U>) {
+  public map<U>(fn: (stream$: Observable<T>) => Observable<U>) {
     this.mapFn = fn
     return this as any as Http<U>
   }


### PR DESCRIPTION
...从而令 ts 能正确推导出传入 mapfn 的输入类型（`Observable<T>`），并通
过传入 mapfn 的输出类型（`Observable<U>`）推导出 map 所得 Http 对象的类
型（`Http<U>`）。

注：修正前 map 方法的类型定义是错的，里面涉及的类型参数名 U 分属两个类
型参数，并不相同，具有迷惑性。