### PR TITLE
令 SDKFetch 上的 get/put/post/delete 方法默认返回 Observable

### DIFF
--- a/src/apis/event/get.ts
+++ b/src/apis/event/get.ts
@@ -1,6 +1,6 @@
 import 'rxjs/add/operator/toArray'
+import { Observable } from 'rxjs/Observable'
 import { QueryToken } from 'reactivedb'
-import { Http } from '../../Net'
 import { SDKFetch } from '../../SDKFetch'
 import { SDK, CacheStrategy } from '../../SDK'
 import { EventSchema } from '../../schemas/Event'
@@ -11,7 +11,7 @@ export function getEventFetch(
   this: SDKFetch,
   eventId: EventId,
   query?: any
-): Http<EventSchema[]> {
+): Observable<EventSchema[]> {
   return this.get<EventSchema[]>(`events/${eventId}`, query)
 }
 

--- a/src/apis/file/get.ts
+++ b/src/apis/file/get.ts
@@ -1,6 +1,6 @@
+import { Observable } from 'rxjs/Observable'
 import { QueryToken } from 'reactivedb'
 import { SDK, CacheStrategy } from '../../SDK'
-import { Http } from '../../Net'
 import { SDKFetch } from '../../SDKFetch'
 import { FileSchema } from '../../schemas/File'
 import { FileId } from 'teambition-types'
@@ -9,7 +9,7 @@ export function getFileFetch(
   this: SDKFetch,
   fileId: FileId,
   query?: any
-): Http<FileSchema> {
+): Observable<FileSchema> {
   return this.get<FileSchema>(`works/${fileId}`, query)
 }
 

--- a/src/apis/like/get.ts
+++ b/src/apis/like/get.ts
@@ -1,18 +1,18 @@
 import { Observable } from 'rxjs/Observable'
 import { QueryToken } from 'reactivedb'
 import { LikeSchema } from '../../schemas/Like'
-import { Http } from '../../Net'
 import { SDKFetch } from '../../SDKFetch'
 import { SDK, CacheStrategy } from '../../SDK'
 import { DetailObjectId, DetailObjectType } from 'teambition-types'
 
-export function getLikeFetch (this: SDKFetch, objectType: DetailObjectType, objectId: DetailObjectId): Http<LikeSchema> {
+export function getLikeFetch (
+  this: SDKFetch,
+  objectType: DetailObjectType,
+  objectId: DetailObjectId
+): Observable<LikeSchema> {
   const fetchNamespace = objectType !== 'entry' ? `${objectType}s` : 'entries'
   return this.get<LikeSchema>(`${fetchNamespace}/${objectId}/like`, { all: '1' })
-      .map((v$: Observable<LikeSchema>) => v$.map(r => {
-        r._id = `${objectId}:like`
-        return r
-       }))
+    .map(r => ({ ...r, _id: `${objectId}:like` }))
 }
 
 SDKFetch.prototype.getLike = getLikeFetch

--- a/src/apis/like/toggleLike.ts
+++ b/src/apis/like/toggleLike.ts
@@ -1,6 +1,5 @@
 import { Observable } from 'rxjs/Observable'
 import { LikeSchema } from '../../schemas/Like'
-import { Http } from '../../Net'
 import { SDKFetch } from '../../SDKFetch'
 import { SDK } from '../../SDK'
 import { DetailObjectId, DetailObjectType } from 'teambition-types'
@@ -10,14 +9,14 @@ export function toggleLikeFetch (
   objectType: DetailObjectType,
   objectId: DetailObjectId,
   isLike: boolean
-): Http<LikeSchema> {
+): Observable<LikeSchema> {
   const fetchNamespace = objectType !== 'entry' ? `${objectType}s` : 'entries'
   const uri = `${fetchNamespace}/${objectId}/like`
   const dist = isLike ? this.delete<LikeSchema>(uri) : this.post<LikeSchema>(uri)
-  return dist.map((v$: Observable<LikeSchema>) => v$.map(r => {
-        r._id = `${objectId}:like`
-        return r
-       }))
+  return dist.map(r => {
+    r._id = `${objectId}:like`
+    return r
+  })
 }
 
 SDKFetch.prototype.toggleLike = toggleLikeFetch

--- a/src/apis/my/count.ts
+++ b/src/apis/my/count.ts
@@ -1,6 +1,5 @@
 import { Observable } from 'rxjs/Observable'
 import { SDKFetch } from '../../SDKFetch'
-import { Http } from '../../Net'
 import { SDK } from '../../SDK'
 
 export interface MyCountData {
@@ -14,7 +13,7 @@ export interface MyCountData {
 
 export function getMyCountFetch(
   this: SDKFetch
-): Http<MyCountData> {
+): Observable<MyCountData> {
   return this.get<MyCountData>(`users/me/count`)
 }
 
@@ -29,7 +28,7 @@ declare module '../../SDKFetch' {
 export function getMyCount(
   this: SDK
 ): Observable<MyCountData> {
-  return this.fetch.getMyCount().send()
+  return this.fetch.getMyCount()
 }
 
 SDK.prototype.getMyCount = getMyCount

--- a/src/apis/my/recent.ts
+++ b/src/apis/my/recent.ts
@@ -1,7 +1,6 @@
 import { Observable } from 'rxjs/Observable'
 import { QueryToken } from 'reactivedb'
 import { forEach } from '../../utils'
-import { Http } from '../../Net'
 import { SDKFetch } from '../../SDKFetch'
 import { SDK, CacheStrategy } from '../../SDK'
 import { TaskSchema, EventSchema, SubtaskSchema } from '../../schemas'
@@ -32,7 +31,7 @@ export type RecentResult = EventGenerator | RecentSubtaskData | RecentTaskData
 export function getMyRecentFetch(
   this: SDKFetch,
   query: MyRecentQuery
-): Http<RecentData[]> {
+): Observable<RecentData[]> {
   return this.get<RecentData[]>(`users/recent`, query)
 }
 
@@ -54,9 +53,7 @@ export function getMyRecent(
     cacheValidate: CacheStrategy.Request,
     tableName: 'Task',
     request: this.fetch.getMyRecent(query)
-              .map((v$: Observable<RecentData[]>) =>
-                v$.map(r =>
-                  r.filter(t => t.type === 'task'))),
+              .map(r => r.filter(t => t.type === 'task')),
     query: {
       where: {
         dueDate: {
@@ -123,9 +120,7 @@ export function getMyRecent(
     cacheValidate: CacheStrategy.Request,
     tableName: 'Event',
     request: this.fetch.getMyRecent(query)
-              .map((v$: Observable<RecentData[]>) =>
-                v$.map(r =>
-                  r.filter(t => t.type === 'event'))),
+               .map(r => r.filter(t => t.type === 'event')),
     query: eventQuery,
     assocFields: {
       project: ['_id', 'name', 'isArchived']
@@ -148,9 +143,7 @@ export function getMyRecent(
     cacheValidate: CacheStrategy.Request,
     tableName: 'Subtask',
     request: this.fetch.getMyRecent(query)
-              .map((v$: Observable<RecentData[]>) =>
-                v$.map(r =>
-                  r.filter(t => t.type === 'subtask'))),
+              .map(r => r.filter(t => t.type === 'subtask')),
     query: {
       where: {
         _executorId: userId,

--- a/src/apis/organization/projects.ts
+++ b/src/apis/organization/projects.ts
@@ -1,5 +1,5 @@
+import { Observable } from 'rxjs/Observable'
 import { OrganizationId, TagId } from 'teambition-types'
-import { Http } from '../../Net'
 import { SDKFetch } from '../../SDKFetch'
 import { ProjectSchema } from '../../schemas/Project'
 import { UrlPagingQuery } from '../../utils/internalTypes'
@@ -8,7 +8,7 @@ export function getAllOrganizationProjects(
   this: SDKFetch,
   orgId: OrganizationId,
   query?: UrlPagingQuery
-): Http<ProjectSchema> {
+): Observable<ProjectSchema> {
   return this.get<ProjectSchema>(`organizations/${orgId}/projects/all`, query)
 }
 
@@ -16,7 +16,7 @@ export function getJoinedOrganizationProjects(
   this: SDKFetch,
   orgId: OrganizationId,
   query?: UrlPagingQuery
-): Http<ProjectSchema> {
+): Observable<ProjectSchema> {
   return this.get<ProjectSchema>(`organizations/${orgId}/projects/joined`, query)
 }
 
@@ -24,14 +24,14 @@ export function getPublicOrganizationProjects(
   this: SDKFetch,
   orgId: OrganizationId,
   query?: UrlPagingQuery
-): Http<ProjectSchema> {
+): Observable<ProjectSchema> {
   return this.get<ProjectSchema>(`organizations/${orgId}/projects/public`, query)
 }
 
 export function getStarredOrganizationProjects(
   this: SDKFetch,
   orgId: OrganizationId
-): Http<ProjectSchema> {
+): Observable<ProjectSchema> {
   return this.get<ProjectSchema>(`organizations/${orgId}/projects/starred`)
 }
 
@@ -40,14 +40,14 @@ export function getOrganizationProjectsByTagId(
   orgId: OrganizationId,
   tagId: TagId,
   query?: UrlPagingQuery
-): Http<ProjectSchema> {
+): Observable<ProjectSchema> {
   return this.get<ProjectSchema>(`organizations/${orgId}/projecttags/${tagId}/projects`, query)
 }
 
 export function getUngroupedOrganizationProjects(
   this: SDKFetch,
   orgId: OrganizationId
-): Http<ProjectSchema> {
+): Observable<ProjectSchema> {
   return this.get<ProjectSchema>(`organizations/${orgId}/projects/ungrouped`)
 }
 

--- a/src/apis/post/create.ts
+++ b/src/apis/post/create.ts
@@ -1,6 +1,5 @@
 import { Observable } from 'rxjs/Observable'
 import { SDK } from '../../SDK'
-import { Http } from '../../Net'
 import { SDKFetch } from '../../SDKFetch'
 import { PostModeOptions, PostSchema } from '../../schemas/Post'
 import { ProjectId, Visibility, FileId, UserId, TagId } from 'teambition-types'
@@ -16,7 +15,7 @@ export interface CreatePostOptions {
   tagIds?: TagId[]
 }
 
-export function createPostFetch(this: SDKFetch, options: CreatePostOptions): Http<PostSchema> {
+export function createPostFetch(this: SDKFetch, options: CreatePostOptions): Observable<PostSchema> {
   return this.post<PostSchema>('posts', options)
 }
 

--- a/src/apis/post/delete.ts
+++ b/src/apis/post/delete.ts
@@ -1,13 +1,12 @@
 import { Observable } from 'rxjs/Observable'
 import { SDK } from '../../SDK'
-import { Http } from '../../Net'
 import { SDKFetch } from '../../SDKFetch'
 import { PostId } from 'teambition-types'
 
 export function deletePostFetch (
   this: SDKFetch,
   _postId: PostId
-): Http<void> {
+): Observable<void> {
   return this.delete<void>(`posts/delete/${_postId}`)
 }
 

--- a/src/apis/post/get.ts
+++ b/src/apis/post/get.ts
@@ -1,6 +1,6 @@
+import { Observable } from 'rxjs/Observable'
 import { QueryToken } from 'reactivedb'
 import { SDK, CacheStrategy } from '../../SDK'
-import { Http } from '../../Net'
 import { SDKFetch } from '../../SDKFetch'
 import { PostSchema } from '../../schemas/Post'
 import { PostId } from 'teambition-types'
@@ -9,7 +9,7 @@ export function getPostFetch(
   this: SDKFetch,
   postId: PostId,
   query?: any
-): Http<PostSchema> {
+): Observable<PostSchema> {
   return this.get<PostSchema>(`posts/${postId}`, query)
 }
 

--- a/src/apis/post/getByTagId.ts
+++ b/src/apis/post/getByTagId.ts
@@ -1,8 +1,8 @@
+import { Observable } from 'rxjs/Observable'
 import { Query, QueryToken, OrderDescription } from 'reactivedb'
 import { SDK, CacheStrategy } from '../../SDK'
 import { TagId } from 'teambition-types'
 import { PostSchema } from '../../schemas/Post'
-import { Http } from '../../Net'
 import { SDKFetch } from '../../SDKFetch'
 import { normPagingQuery } from '../../utils'
 import { PagingQuery, UrlPagingQuery } from '../../utils/internalTypes'
@@ -21,7 +21,7 @@ export function getByTagIdFetch(
   this: SDKFetch,
   tagId: TagId,
   query?: GetPostsByTagIdUrlQuery
-): Http<PostSchema[]> {
+): Observable<PostSchema[]> {
   return this.get<PostSchema[]>(`tags/${tagId}/posts`, query)
 }
 

--- a/src/apis/post/getProjects.ts
+++ b/src/apis/post/getProjects.ts
@@ -1,6 +1,6 @@
-import { Query, QueryToken, OrderDescription  } from 'reactivedb'
+import { Observable } from 'rxjs/Observable'
+import { QueryToken, OrderDescription, Query } from 'reactivedb'
 import { SDK, CacheStrategy } from '../../SDK'
-import { Http } from '../../Net'
 import { SDKFetch } from '../../SDKFetch'
 import { ProjectId } from 'teambition-types'
 import { PostSchema } from '../../schemas/Post'
@@ -26,7 +26,7 @@ export function getPostsFetch<T extends ProjectPostType>(
   this: SDKFetch,
   _projectId: ProjectId,
   query: GetPostsUrlQuery<T>
-): Http<PostSchema[]> {
+): Observable<PostSchema[]> {
   return this.get<PostSchema[]>(`projects/${_projectId}/posts`, query)
 }
 

--- a/src/apis/post/update.ts
+++ b/src/apis/post/update.ts
@@ -2,7 +2,6 @@ import { Observable } from 'rxjs/Observable'
 import { FileId, UserId, PostId } from 'teambition-types'
 import { SDK } from '../../SDK'
 import { SDKFetch } from '../../SDKFetch'
-import { Http } from '../../Net'
 import { PostModeOptions } from '../../schemas/Post'
 
 export interface UpdatePostOptions {
@@ -18,7 +17,7 @@ export function updatePostFetch(
   this: SDKFetch,
   _id: PostId,
   options: UpdatePostOptions
-): Http<typeof options> {
+): Observable<typeof options> {
   return this.put<typeof options>(`posts/${_id}`, options)
 }
 

--- a/src/apis/project/personal.ts
+++ b/src/apis/project/personal.ts
@@ -1,4 +1,4 @@
-import { Http } from '../../Net'
+import { Observable } from 'rxjs/Observable'
 import { SDKFetch } from '../../SDKFetch'
 import { ProjectSchema } from '../../schemas/Project'
 import { UrlPagingQuery } from '../../utils/internalTypes'
@@ -15,7 +15,7 @@ export interface GetPersonalProjectsUrlQuery
 export function getPersonalProjects(
   this: SDKFetch,
   query: GetPersonalProjectsUrlQuery
-): Http<ProjectSchema[]> {
+): Observable<ProjectSchema[]> {
   return this.get<ProjectSchema[]>('projects/personal', query)
 }
 

--- a/src/apis/search/members.ts
+++ b/src/apis/search/members.ts
@@ -1,5 +1,5 @@
+import { Observable } from 'rxjs/Observable'
 import { UserId, TeamId, ProjectId, OrganizationId, GroupId } from 'teambition-types'
-import { Http } from '../../Net'
 import { SDKFetch } from '../../SDKFetch'
 
 /**
@@ -56,7 +56,7 @@ export const buildPath = (scope: Scope): string | null => {
   }
 }
 
-function fetch(this: SDKFetch, scope: Scope, searchString: string): Http<MembersSearchResponse> {
+function fetch(this: SDKFetch, scope: Scope, searchString: string): Observable<MembersSearchResponse> {
   const path = buildPath(scope)
   if (!path) {
     throw `failed to build path for _groupType: ${scope.type} with _groupId: ${scope.id}`
@@ -64,27 +64,27 @@ function fetch(this: SDKFetch, scope: Scope, searchString: string): Http<Members
   return this.get<MembersSearchResponse>(path, { q: searchString })
 }
 
-export function searchMembersInTeam(this: SDKFetch, teamId: TeamId, searchString: string): Http<MembersSearchResponse> {
+export function searchMembersInTeam(this: SDKFetch, teamId: TeamId, searchString: string): Observable<MembersSearchResponse> {
   const targetTeam: Scope = { id: teamId, type: ScopeType.Team }
   return fetch.call(this, targetTeam, searchString)
 }
 
-export function searchMembersInProject(this: SDKFetch, projectId: ProjectId, searchString: string): Http<MembersSearchResponse> {
+export function searchMembersInProject(this: SDKFetch, projectId: ProjectId, searchString: string): Observable<MembersSearchResponse> {
   const targetProject: Scope = { id: projectId, type: ScopeType.Project }
   return fetch.call(this, targetProject, searchString)
 }
 
-export function searchMembersInOrganization(this: SDKFetch, orgId: OrganizationId, searchString: string): Http<MembersSearchResponse> {
+export function searchMembersInOrganization(this: SDKFetch, orgId: OrganizationId, searchString: string): Observable<MembersSearchResponse> {
   const targetOrg: Scope = { id: orgId, type: ScopeType.Organization }
   return fetch.call(this, targetOrg, searchString)
 }
 
-export function searchMembersInGroup(this: SDKFetch, groupId: GroupId, searchString: string): Http<MembersSearchResponse> {
+export function searchMembersInGroup(this: SDKFetch, groupId: GroupId, searchString: string): Observable<MembersSearchResponse> {
   const targetGroup: Scope = { id: groupId, type: ScopeType.Group }
   return fetch.call(this, targetGroup, searchString)
 }
 
-export function searchMembers(this: SDKFetch, searchString: string): Http<MembersSearchResponse> {
+export function searchMembers(this: SDKFetch, searchString: string): Observable<MembersSearchResponse> {
   return fetch.call(this, {}, searchString)
 }
 

--- a/src/apis/task/get.ts
+++ b/src/apis/task/get.ts
@@ -1,5 +1,5 @@
+import { Observable } from 'rxjs/Observable'
 import { QueryToken } from 'reactivedb'
-import { Http } from '../../Net'
 import { SDKFetch } from '../../SDKFetch'
 import { SDK, CacheStrategy } from '../../SDK'
 import { TaskSchema } from '../../schemas/Task'
@@ -9,7 +9,7 @@ export function getTaskFetch(
   this: SDKFetch,
   taskId: TaskId,
   query?: any
-): Http<TaskSchema> {
+): Observable<TaskSchema> {
   return this.get<TaskSchema>(`events/${taskId}`, query)
 }
 

--- a/src/apis/user/addEmail.ts
+++ b/src/apis/user/addEmail.ts
@@ -1,12 +1,11 @@
 import { Observable } from 'rxjs/Observable'
 import { SDK } from '../../SDK'
-import { Http } from '../../Net'
 import { SDKFetch } from '../../SDKFetch'
 
 export function addEmailFetch (
   this: SDKFetch,
   email: string
-): Http<any> {
+): Observable<any> {
   return this.post<any>('users/email', { email })
 }
 

--- a/src/apis/user/update.ts
+++ b/src/apis/user/update.ts
@@ -1,12 +1,11 @@
 import { Observable } from 'rxjs/Observable'
 import { SDK } from '../../SDK'
-import { Http } from '../../Net'
 import { SDKFetch } from '../../SDKFetch'
 
 export function updateUserFetch<T> (
   this: SDKFetch,
   patch: T
-): Http<T> {
+): Observable<T> {
   return this.put<T>('users', patch)
 }
 

--- a/src/fetchs/SocketFetch.ts
+++ b/src/fetchs/SocketFetch.ts
@@ -1,0 +1,20 @@
+import { SDKFetch } from '../SDKFetch'
+
+export class SocketFetch extends SDKFetch {
+  join(room: string, consumerId: string): Promise<void> {
+    return this.post<void>(`${room}/subscribe`, {
+      consumerId: consumerId
+    })
+    .toPromise()
+  }
+
+  leave(room: string, consumerId: string): Promise<void> {
+    // http delete 不允许有 body， 但是这里就是有 body
+    return this.delete<void>(`${room}/subscribe`, {
+      consumerId
+    })
+    .toPromise()
+  }
+}
+
+export default new SocketFetch()

--- a/src/sockets/SocketClient.ts
+++ b/src/sockets/SocketClient.ts
@@ -169,7 +169,6 @@ export class SocketClient {
 
   private _getToken() {
     return this.fetch.getUserMe()
-      .send()
       .toPromise()
       .then((r: UserMe) => {
         this._getUserMeStream.next(r)
@@ -195,7 +194,6 @@ export function leaveRoom(
 ) {
   // http delete 不允许有 body， 但是这里就是有 body
   return this.delete<void>(`${room}/subscribe`, { consumerId })
-    .send()
     .toPromise()
 }
 
@@ -205,7 +203,6 @@ export function joinRoom(
   consumerId: string
 ) {
   return this.post<void>(`${room}/subscribe`, { consumerId })
-    .send()
     .toPromise()
 }
 

--- a/test/apis/organization.spec.ts
+++ b/test/apis/organization.spec.ts
@@ -63,7 +63,6 @@ describe('get organization projects', () => {
         fetchMock.getOnce(expectedUrl, expectedResponse)
 
         yield fn.call(sdkFetch, sampleOrgId)
-          .send()
           .subscribeOn(Scheduler.async)
           .do((x: any) => {
             expect(x).to.deep.equal(expectedResponse)
@@ -79,7 +78,6 @@ describe('get organization projects', () => {
       fetchMock.getOnce(expectedUrl, expectedResponse)
 
       yield sdkFetch.getOrganizationProjectsByTagId(sampleOrgId, sampleTagId)
-        .send()
         .subscribeOn(Scheduler.async)
         .do((x: any) => {
           expect(x).to.deep.equal(expectedResponse)

--- a/test/apis/project.spec.ts
+++ b/test/apis/project.spec.ts
@@ -75,7 +75,6 @@ describe('get personal projects', () => {
         }
 
         yield sdkFetch.getPersonalProjects(params as any)
-          .send()
           .subscribeOn(Scheduler.async)
           .do((x: any) => {
             expect(x).to.deep.equal(expectedResponse)

--- a/test/apis/search.spec.ts
+++ b/test/apis/search.spec.ts
@@ -102,7 +102,6 @@ describe('search for members', () => {
         fetchMock.getOnce(`/${namespace}/${sampleId}/members/search?q=&_=666`, expectedResultSet)
 
         yield fn.call(sdkFetch, sampleId as any, '')
-          .send()
           .subscribeOn(Scheduler.async)
           .do((x: any) => {
             expect(x).to.deep.equal(expectedResultSet)
@@ -116,7 +115,6 @@ describe('search for members', () => {
         fetchMock.getOnce(`/${namespace}/${sampleId}/members/search?q=nonExistence&_=666`, expectedResultSet)
 
         yield fn.call(sdkFetch, sampleId as any, 'nonExistence')
-          .send()
           .subscribeOn(Scheduler.async)
           .do((x: any) => {
             expect(x).to.deep.equal(expectedResultSet)
@@ -130,7 +128,6 @@ describe('search for members', () => {
         fetchMock.getOnce(`/${namespace}/${sampleId}/members/search?q=shuai&_=666`, expectedResultSet)
 
         yield fn.call(sdkFetch, sampleId as any, 'shuai')
-          .send()
           .subscribeOn(Scheduler.async)
           .do((x: any) => {
             expect(x).to.deep.equal(expectedResultSet)
@@ -142,7 +139,6 @@ describe('search for members', () => {
       fetchMock.get('/members/search?q=&_=666', allMembers)
 
       yield sdkFetch.searchMembers('')
-        .send()
         .subscribeOn(Scheduler.async)
         .do((x) => {
           expect(x).to.deep.equal(allMembers)
@@ -153,7 +149,6 @@ describe('search for members', () => {
       fetchMock.get('/members/search?q=nonExistence&_=666', [])
 
       yield sdkFetch.searchMembers('nonExistence')
-        .send()
         .subscribeOn(Scheduler.async)
         .do((x) => {
           expect(x).to.deep.equal([])
@@ -165,7 +160,6 @@ describe('search for members', () => {
       fetchMock.get('/members/search?q=shuai&_=666', expectedResultSet)
 
       yield sdkFetch.searchMembers('shuai')
-        .send()
         .subscribeOn(Scheduler.async)
         .do((x) => {
           expect(x).to.deep.equal(expectedResultSet)

--- a/test/net/net.ts
+++ b/test/net/net.ts
@@ -234,7 +234,7 @@ describe('Net test', () => {
           'involvers', 'likesCount'
         ],
         required: ['startDate'],
-        padding: (id: string) => sdkFetch.get<any>(`api/events/${id}`).send()
+        padding: (id: string) => sdkFetch.get<any>(`api/events/${id}`)
       })
         .changes()
         .publishReplay(1)
@@ -286,7 +286,7 @@ describe('Net test', () => {
           'involvers', 'likesCount'
         ],
         required: ['startDate'],
-        padding: (id: string) => sdkFetch.get<any>(`api/events/${id}`).send()
+        padding: (id: string) => sdkFetch.get<any>(`api/events/${id}`)
       })
         .changes()
         .publishReplay(1)
@@ -435,7 +435,7 @@ describe('Net test', () => {
           'involvers', 'likesCount'
         ],
         required: ['startDate'],
-        padding: (id: string) => sdkFetch.get<any>(`api/events/${id}`).send()
+        padding: (id: string) => sdkFetch.get<any>(`api/events/${id}`)
       })
 
       yield getToken()
@@ -497,7 +497,7 @@ describe('Net test', () => {
           'involvers', 'likesCount'
         ],
         required: ['startDate'],
-        padding: (id: string) => sdkFetch.get<any>(`api/events/${id}`).send()
+        padding: (id: string) => sdkFetch.get<any>(`api/events/${id}`)
       } as ApiResult<EventSchema, 2313>)
 
       expect(fn).to.throw('unreachable code path')
@@ -516,7 +516,7 @@ describe('Net test', () => {
           'involvers', 'likesCount'
         ],
         required: ['startDate'],
-        padding: (id: string) => sdkFetch.get<any>(`api/events/${id}`).send()
+        padding: (id: string) => sdkFetch.get<any>(`api/events/${id}`)
       } as ApiResult<EventSchema, CacheStrategy.Request> )
 
       expect(fn).to.throw('table: __NOT_EXIST__ is not defined')


### PR DESCRIPTION
...而不是 Http 对象。

- [x] 将 X-Request-Id 移出 Net/Net
- [x] 将 X-Request-Id 移出 Net/Http
- [x] 修改 SDKFetch 上 get/put/post/delete 接口
- [x] 在匹配项目中创建使用新接口的分支

为 SDKFetch HTTP 方法接口提供 options 参数，如下：

```typescript
export interface SDKFetchOptions {
  includeHeaders?: boolean, // 结果是否包含 response headers
  wrapped?: boolean         // 返回 Http 对象还是返回 Observable
}
```

在 SDKFetch 的 HTTP 方法接口上，做了如下修改：

> 每个方法在原有参数列表之后添加一个 options 参数，默认值为 `{}`。即：默认不需要 response headers，且直接返回 Observable。
>
> 当且仅当传入 options 参数里有 `wrapped` 字段的值为真，返回 Http 对象，其余情况均返回 Observable。

在 Http 的接口上，保留原有设计，调用 `get/put/post/delete` 之后需要通过再调用 `send` 获得 Observable<_response_>。仅做的修改如下：

> 在 Http 构造函数的原参数列表上添加了一个 `includeHeaders` 参数，默认值为 `false`。即：默认不需要 response headers。

在使用到接口的地方，有这样几个改变（或者说回溯到引入 Http 之前的使用方法）：

> 直接调用 SDKFetch 对象上的 `get/put/post/delete` 方法时，不再需要调用 `send()`。
>
> 调用 SDKFetch 对象上的各种 fetch api 接口时，也不再需要调用 `send()`。
>
> 在构造 `Net.prototype.lift` 上的 `request` 字段参数时，传入 Observable。如果源 Observable 需要转换，可以直接在 Observable 上写 map。

即：在使用者这里，日常情况下不再需要直接接触 Http 对象，而是回归到使用更稳定、更易操作的 Observable<_response_>。

**注：**

之所以引入 `includeHeaders` 这个与本 issue 不是直接相关的 flag，是为了保留对 X-Request-Id 这个自定义 headers field 的使用（虽然其实目前并没有地方在使用这个功能）。

...resolves #281 