### PR TITLE
fix(sockets/EventMaps): 纠正从 destroy/remove 消息到数据库操作的映射

### DIFF
--- a/mock/socket.ts
+++ b/mock/socket.ts
@@ -58,12 +58,13 @@ export class SocketMock {
   emit(
     method: 'change' | 'destroy' | 'new' | 'refresh' | 'remove',
     objectType: SocketEventType,
-    objectId: string,
+    objectId?: string,
     patch?: any,
     delay: number | Promise<any> | ToPromiseObject = 0
   ): Promise<any> {
+    const eTail = objectId ? `/${objectId}` : ''
     const params = {
-      e: `:${method}:${objectType}/${objectId}`,
+      e: `:${method}:${objectType}${eTail}`,
       d: patch
     }
 

--- a/test/sockets/sockets.spec.ts
+++ b/test/sockets/sockets.spec.ts
@@ -45,6 +45,55 @@ describe('Socket handling Spec', () => {
 
     expect(r).to.be.null
   })
+
+  it('should do db:remove on { e: ":destroy:{modelType}/{modelId}", d: "" }', function* () {
+    const modelId = '587ee5510f399a3a37e0e182'
+    const postSample = {
+      _id: '587ee5510f399a3a37e0e182',
+      _projectId: '56988fb705ead4ae7bb8dcfe'
+    }
+
+    yield sdk.database.insert('Post', postSample)
+
+    yield socket.emit('destroy', 'post', modelId)
+
+    yield sdk.database.get('Post', { where: { _id: modelId } })
+      .values()
+      .do((r) => expect(r.length).to.equal(0))
+  })
+
+  it('should do db:remove on { e: ":remove:{collectionType}/{collectionId}", d: "{modelId}" }', function* () {
+    const collectionId = '597fdea5528664cd3c81ebfa'
+    const modelId = '597fdea5528664cd3c81ebfd'
+    const stageSample = {
+      _id: modelId,
+      _tasklistId: collectionId
+    }
+
+    yield sdk.database.insert('Stage', stageSample)
+
+    yield socket.emit('remove', 'stages' as any, collectionId, modelId)
+
+    yield sdk.database.get('Stage', { where: { _id: modelId } })
+      .values()
+      .do((r) => expect(r.length).to.equal(0))
+  })
+
+  it('should do db:remove on { e: ":remove:{collectionType}", d: "{modelId}" }', function* () {
+    const modelId = '59a3aea25e25ef050c28ce4f'
+    const commentSample = {
+      _id: modelId,
+      action: 'activity.comment'
+    }
+
+    yield sdk.database.insert('Activity', commentSample)
+
+    yield socket.emit('remove', 'activities' as any, '', modelId)
+
+    yield sdk.database.get('Activity', { where: { _id: modelId } })
+      .values()
+      .do((r) => expect(r.length).to.equal(0))
+  })
 })
 
 describe('join/leave `room`', () => {


### PR DESCRIPTION
...修改从 destroy/remove 分别获取要删除的条目 id 的方法。即：

{ e: ":destroy:{modelType}/{modelId}", d: "" }
从 e 字段获取 modelId 作为要删除的条目 id；

{ e: ":remove:{collectionType}/{collectionId}", d: "{modelId}" }
从 d 字段获取 modelId 作为要删除的条目 id；

{ e: ":remove:{collectionType}", d: "{modelId}" }
不论 e 字段是否带有 id 后缀，使用 d 字段作为要删除的条目 id。