### PR TITLE
DO NOT MERGE fix(schemas/member): 添加 ProjectMember 和 OrganizationMember 表

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teambition-sdk",
-  "version": "0.8.19",
+  "version": "0.8.20-alpha.1-members-fix",
   "description": "Front-End SDK for Teambition",
   "main": "./index.js",
   "typings": "./index.d.ts",

--- a/src/schemas/Member.ts
+++ b/src/schemas/Member.ts
@@ -79,4 +79,8 @@ const Schema: SchemaDef<MemberSchema> = {
   website: { type: RDBType.STRING },
 }
 
-schemas.push({ schema: Schema, name: 'Member' })
+schemas.push(
+  { schema: Schema, name: 'Member' },
+  { schema: Schema, name: 'ProjectMember' },
+  { schema: Schema, name: 'OrganizationMember' }
+)

--- a/src/schemas/Project.ts
+++ b/src/schemas/Project.ts
@@ -114,7 +114,7 @@ const Schema: SchemaDef<ProjectSchema> = {
   creator: {
     type: Relationship.oneToOne,
     virtual: {
-      name: 'Member',
+      name: 'ProjectMember',
       where: (memberTable: any) => ({
         _creatorId: memberTable._id
       })


### PR DESCRIPTION
...以暂时解决 Member 数据中 _boundToObjectType 字段遭到互相覆盖的问题，
影响上层查询的可靠性。

这两张表基于现有的 Member schema。