### PR TITLE
 fix(SDKFetch, Http): 修复原接口不支持用户为单个请求定制配置的问题

### DIFF
--- a/src/Net/Http.ts
+++ b/src/Net/Http.ts
@@ -139,6 +139,11 @@ export class Http<T> {
   private static post = createMethod('post')
   private static delete = createMethod('delete')
 
+  private static defaultOpts = () => ({
+    headers: {},
+    credentials: 'include'
+  })
+
   constructor(
     private url: string = '',
     errorAdapter$?: Subject<HttpErrorMessage>,
@@ -151,13 +156,7 @@ export class Http<T> {
     }
   }
 
-  private _opts: any = {
-    headers: {
-      'Accept': 'application/json',
-      'Content-Type': 'application/json'
-    },
-    credentials: 'include'
-  }
+  private _opts: any = Http.defaultOpts()
 
   map<U>(fn: (stream$: Observable<T>) => Observable<U>) {
     this.mapFn = fn
@@ -186,13 +185,7 @@ export class Http<T> {
   }
 
   restore() {
-    this._opts = {
-      headers: {
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-      },
-      credentials: 'include'
-    }
+    this._opts = Http.defaultOpts()
     return this
   }
 

--- a/src/SDKFetch.ts
+++ b/src/SDKFetch.ts
@@ -25,12 +25,20 @@ export class SDKFetch {
   static FetchStack = new Map<string, Observable<any>>()
   static fetchTail: string | undefined | 0
 
-  get<T>(path: string, query: any, options: { wrapped: true, includeHeaders: true }): Http<HttpResponseWithHeaders<T>>
-  get<T>(path: string, query: any, options: { wrapped: true, includeHeaders: false }): Http<T>
-  get<T>(path: string, query: any, options: { wrapped: false, includeHeaders: true }): Observable<HttpResponseWithHeaders<T>>
-  get<T>(path: string, query: any, options: { wrapped: true }): Http<T>
-  get<T>(path: string, query: any, options: { includeHeaders: true }): Observable<HttpResponseWithHeaders<T>>
+  get<T>(path: string, query: any, options: SDKFetchOptions & {
+    wrapped: true, includeHeaders: true
+  }): Http<HttpResponseWithHeaders<T>>
+
+  get<T>(path: string, query: any, options: SDKFetchOptions & {
+    wrapped: true
+  }): Http<T>
+
+  get<T>(path: string, query: any, options: SDKFetchOptions & {
+    includeHeaders: true
+  }): Observable<HttpResponseWithHeaders<T>>
+
   get<T>(path: string, query?: any, options?: SDKFetchOptions): Observable<T>
+
   get<T>(path: string, query?: any, options: SDKFetchOptions = {}) {
     const url = this.urlWithPath(path)
     const urlWithQuery = query ? this._buildQuery(url, query) : url
@@ -70,12 +78,20 @@ export class SDKFetch {
     return `${this.apiHost}/${path}`
   }
 
-  post<T>(path: string, body: any, options: { wrapped: true, includeHeaders: true }): Http<HttpResponseWithHeaders<T>>
-  post<T>(path: string, body: any, options: { wrapped: true, includeHeaders: false }): Http<T>
-  post<T>(path: string, body: any, options: { wrapped: false, includeHeaders: true }): Observable<HttpResponseWithHeaders<T>>
-  post<T>(path: string, body: any, options: { wrapped: true }): Http<T>
-  post<T>(path: string, body: any, options: { includeHeaders: true }): Observable<HttpResponseWithHeaders<T>>
+  post<T>(path: string, body: any, options: SDKFetchOptions & {
+    wrapped: true, includeHeaders: true
+  }): Http<HttpResponseWithHeaders<T>>
+
+  post<T>(path: string, body: any, options: SDKFetchOptions & {
+    wrapped: true
+  }): Http<T>
+
+  post<T>(path: string, body: any, options: SDKFetchOptions & {
+    includeHeaders: true
+  }): Observable<HttpResponseWithHeaders<T>>
+
   post<T>(path: string, body?: any, options?: SDKFetchOptions): Observable<T>
+
   post<T>(path: string, body?: any, options: SDKFetchOptions = {}) {
     const http = options.includeHeaders ? getHttpWithResponseHeaders<T>() : new Http<T>()
 
@@ -85,12 +101,20 @@ export class SDKFetch {
     return options.wrapped ? http : http['request']
   }
 
-  put<T>(path: string, body: any, options: { wrapped: true, includeHeaders: true }): Http<HttpResponseWithHeaders<T>>
-  put<T>(path: string, body: any, options: { wrapped: true, includeHeaders: false }): Http<T>
-  put<T>(path: string, body: any, options: { wrapped: false, includeHeaders: true }): Observable<HttpResponseWithHeaders<T>>
-  put<T>(path: string, body: any, options: { includeHeaders: true }): Observable<HttpResponseWithHeaders<T>>
-  put<T>(path: string, body: any, options: { wrapped: true }): Http<T>
+  put<T>(path: string, body: any, options: SDKFetchOptions & {
+    wrapped: true, includeHeaders: true
+  }): Http<HttpResponseWithHeaders<T>>
+
+  put<T>(path: string, body: any, options: SDKFetchOptions & {
+    wrapped: true
+  }): Http<T>
+
+  put<T>(path: string, body: any, options: SDKFetchOptions & {
+    includeHeaders: true
+  }): Observable<HttpResponseWithHeaders<T>>
+
   put<T>(path: string, body?: any, options?: SDKFetchOptions): Observable<T>
+
   put<T>(path: string, body?: any, options: SDKFetchOptions = {}) {
     const http = options.includeHeaders ? getHttpWithResponseHeaders<T>() : new Http<T>()
 
@@ -100,12 +124,20 @@ export class SDKFetch {
     return options.wrapped ? http : http['request']
   }
 
-  delete<T>(path: string, body: any, options: { wrapped: true, includeHeaders: true }): Http<HttpResponseWithHeaders<T>>
-  delete<T>(path: string, body: any, options: { wrapped: true, includeHeaders: false }): Http<T>
-  delete<T>(path: string, body: any, options: { wrapped: false, includeHeaders: true }): Observable<HttpResponseWithHeaders<T>>
-  delete<T>(path: string, body: any, options: { includeHeaders: true }): Observable<HttpResponseWithHeaders<T>>
-  delete<T>(path: string, body: any, options: { wrapped: true }): Http<T>
+  delete<T>(path: string, body: any, options: SDKFetchOptions & {
+    wrapped: true, includeHeaders: true
+  }): Http<HttpResponseWithHeaders<T>>
+
+  delete<T>(path: string, body: any, options: SDKFetchOptions & {
+    wrapped: true
+  }): Http<T>
+
+  delete<T>(path: string, body: any, options: SDKFetchOptions & {
+    includeHeaders: true
+  }): Observable<HttpResponseWithHeaders<T>>
+
   delete<T>(path: string, body?: any, options?: SDKFetchOptions): Observable<T>
+
   delete<T>(path: string, body?: any, options: SDKFetchOptions = {}) {
     const http = options.includeHeaders ? getHttpWithResponseHeaders<T>() : new Http<T>()
 

--- a/test/net/http.ts
+++ b/test/net/http.ts
@@ -34,10 +34,7 @@ export default describe('net/http', () => {
         expect(fetchMock.lastUrl()).to.equal(url)
         expect(fetchMock.lastOptions()).to.deep.equal({
           method: 'get',
-          headers: {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json'
-          },
+          headers: {},
           credentials: 'include'
         })
       })
@@ -54,12 +51,27 @@ export default describe('net/http', () => {
         expect(fetchMock.lastOptions()).to.deep.equal({
           method: 'get',
           headers: {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json',
             'X-Request-Id': '2333'
           },
           credentials: 'include'
         })
+      })
+  })
+
+  it('should set headers with copy of the input headers', function* () {
+    const headers = {}
+
+    fetchInstance.setHeaders(headers)
+
+    // 如果使用的是传入 headers 对象的引用，下面修改会导致最终 headers 被修改
+    headers['X-Request-Id'] = '2333'
+
+    fetchMock.mock(url, {})
+    yield fetchInstance.get()
+      .send()
+      .subscribeOn(Scheduler.async)
+      .do(() => {
+        expect(fetchMock.lastOptions().headers).to.deep.equal({})
       })
   })
 
@@ -74,8 +86,6 @@ export default describe('net/http', () => {
         expect(fetchMock.lastOptions()).to.deep.equal({
           method: 'get',
           headers: {
-            'Accept': 'application/json',
-            'Content-Type': 'application/json',
             'Authorization': `OAuth2 ${token}`
           }
         })
@@ -140,9 +150,9 @@ export default describe('net/http', () => {
       yield fetchInstance2[httpMethod](path, httpMethod === 'get' || httpMethod === 'delete' ? null : body)
         .send()
         .subscribeOn(Scheduler.async)
-        .do((res: any) => {
-          expect(res.body).to.deep.equal(responseData)
-          expect(res.headers['x-request-id']).to.equal(sampleValue)
+        .do((resp: any) => {
+          expect(resp.body).to.deep.equal(responseData)
+          expect(resp.headers['x-request-id']).to.equal(sampleValue)
         })
     })
   })


### PR DESCRIPTION
接口改变：

- ~~SDKFetch 请求方法（get/post/put/delete）的最后一个 options 参数 `wrapped` 字段改名为 `_wrapped`，`includeHeaders` 改名为 `_includeHeaders`。~~

- 该 options 参数添加了对字段 `apiHost`, `token`, 和 `headers` 的支持；并允许用户提供额外的字段。这些 options 将只作用于当前调用方法的请求，不影响 SDKFetch 对象所管理的状态。用户额外添加的字段会被作为真实请求被发出时（Observable.ajax 或 fetch）的 options 参数的对应字段；

- 这里 `headers` 字段接收对象类型，其中有一个可选字段为 `merge`。当用户传入 `headers` 字段对应的对象中，包含 truthy 的 `merge` 值，用户提供的 `headers` 其他字段会以类似于 Object.assign 的形式「添加」到当前 SDKFetch 对象的内部 headers 上；默认情况下，如果 options 参数中 `headers` 的值为 truthy，就会用其「替换」当前 SDKFetch 对象的内部 headers 作为当前请求要使用的 request headers。 

...to resolve #337 .