### PR TITLE
feat(apis/event): 添加日程相关常用的工具函数，及测试

### DIFF
--- a/src/apis/event/EventGenerator.ts
+++ b/src/apis/event/EventGenerator.ts
@@ -1,5 +1,5 @@
 import { EventSchema } from '../../schemas/Event'
-import { isRecurrence } from './utils'
+import { isRecurrent } from './utils'
 import { clone } from '../../utils'
 import { EventId } from 'teambition-types'
 
@@ -14,7 +14,7 @@ export class EventGenerator implements IterableIterator<EventSchema | undefined>
   private done: boolean
   private rrule: any
   private startDateCursor: Date
-  private isRecurrence = isRecurrence(this.event)
+  private isRecurrence = isRecurrent(this.event)
   private duration: number
 
   [Symbol.iterator] = () => this

--- a/src/apis/event/index.ts
+++ b/src/apis/event/index.ts
@@ -1,9 +1,13 @@
 import './get'
 import './request'
 
+export { EventGenerator as Generator } from './EventGenerator'
+
 export {
   CommentsRepeatEvent,
   UpdateInvolveMembers,
   EventCount,
   EventSpan
 } from './request'
+
+export { originEventId, isAllDay, isRecurrent } from './utils'

--- a/src/apis/event/utils.ts
+++ b/src/apis/event/utils.ts
@@ -1,3 +1,43 @@
 import { EventSchema } from '../../schemas/Event'
+import { EventId } from 'teambition-types'
 
-export const isRecurrence = (event: EventSchema) => event.recurrence && event.recurrence.length
+/**
+ * 判断一个日程对象是否为重复日程。
+ * 注意：有重复规则，但仅能推导得零个可用时间点的日程，会返回 true。
+ */
+export const isRecurrent = (event: EventSchema) =>
+  !!event.recurrence && event.recurrence.length > 0
+
+const msPerDay = 24 * 60 * 60 * 1000
+
+// epoch time in current time zone
+const epochTime = new Date(1970, 1, 1).valueOf()
+
+/**
+ * 判断一个日程是否为全天日程。
+ * 目前全天日程的定义为，开始时间为零点，结束时间为第二天零点，或
+ * 接下来第 n 天零点，的日程。
+ * 注意：零点判断根据当地时区得。
+ */
+export const isAllDay = (e: EventSchema): boolean => {
+  const startTime = new Date(e.startDate).valueOf()
+
+  if ((startTime - epochTime) % msPerDay !== 0) {
+    return false
+  }
+
+  const duration = new Date(e.endDate).valueOf() - startTime
+
+  return duration > 0 && duration % msPerDay === 0
+}
+
+/**
+ * 从重复日程实例上生成的 _id 获取原重复日程 _id。
+ * （重复日程在使用时，根据重复规则，常被生成多个日程实例，每个这样的
+ * 日程实例会带区别于原重复日程的 _id。）用例如：在一个重复日程的
+ * 实例上更新数据，则最终需要通过原 _id 来与后端同步，此时，就可以
+ * 使用该函数根据实例上的 _id 获得原 _id。
+ */
+export const originEventId = (id: EventId): EventId => {
+  return id.split('_', 1)[0]
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 /// <reference path="./teambition.ts" />
 import 'tslib'
 
-import { forEach, clone, uuid, concat, dropEle, hasMorePages, pagination } from './utils/index'
+import { forEach, clone, uuid, concat, dropEle, hasMorePages, pagination } from './utils'
 
 export { hasMorePages, pagination }
 export const Utils = { forEach, clone, uuid, concat, dropEle }
@@ -13,6 +13,9 @@ import './apis'
 
 import './schemas'
 export * from './schemas'
+
+import * as EventSDK from './apis/event'
+export { EventSDK }
 
 export { SDK } from './SDK'
 export { SDKFetch } from './SDKFetch'

--- a/test/apis/event/EventGenerator.spec.ts
+++ b/test/apis/event/EventGenerator.spec.ts
@@ -7,9 +7,9 @@ import {
   recurrenceStartAtAnExcludedDate,
   emptyRecurrence,
   normalEvent
-} from '../fixtures/events.fixture'
-import { EventGenerator } from '../../src/apis/event/EventGenerator'
-import { clone } from '../index'
+} from '../../fixtures/events.fixture'
+import { EventGenerator } from '../../../src/apis/event/EventGenerator'
+import { clone } from '../../index'
 
 describe('EventGenerator spec', () => {
   let eventGenerator: EventGenerator

--- a/test/apis/event/event.spec.ts
+++ b/test/apis/event/event.spec.ts
@@ -1,9 +1,9 @@
 import * as moment from 'moment'
 import { describe, beforeEach, afterEach, it } from 'tman'
 import { expect } from 'chai'
-import { createSdk, SDK, SocketMock, EventSchema } from '../index'
-import * as Fixture from '../fixtures/events.fixture'
-import { mock, restore, equals, looseDeepEqual, clone } from '../utils'
+import { createSdk, SDK, SocketMock, EventSchema } from '../../index'
+import * as Fixture from '../../fixtures/events.fixture'
+import { mock, restore, equals, looseDeepEqual, clone } from '../../utils'
 
 describe('EventApi request spec', () => {
   let sdk: SDK

--- a/test/apis/event/index.ts
+++ b/test/apis/event/index.ts
@@ -1,0 +1,3 @@
+import './event.spec'
+import './EventGenerator.spec'
+import './utils.spec'

--- a/test/apis/event/utils.spec.ts
+++ b/test/apis/event/utils.spec.ts
@@ -1,0 +1,98 @@
+import { describe, it } from 'tman'
+import { expect } from 'chai'
+import * as Moment from 'moment'
+
+import {
+  recurrenceByMonth,
+  recurrenceHasEnd,
+  recurrenceStartAtAnExcludedDate,
+  emptyRecurrence,
+  normalEvent
+} from '../../fixtures/events.fixture'
+
+import { EventSDK as e } from '../../../src'
+import { forEachFalsyValueOfProperty } from '../../utils'
+
+describe('Event-related util functions', () => {
+
+  const now = Moment().toISOString()
+
+  it('isRecurrent() should return true for a recurrent event', () => {
+    [recurrenceByMonth, recurrenceHasEnd, recurrenceStartAtAnExcludedDate].forEach((sampleEvent) => {
+      expect(e.isRecurrent(sampleEvent as any)).to.be.true
+    })
+  })
+
+  it('isRecurrent() should return true for an event with rruleset that contains no occurence', () => {
+    expect(e.isRecurrent(emptyRecurrence as any)).to.be.true
+  })
+
+  it('isRecurrent() should return false when param has no or falsy \'recurrence\' property', () => {
+    forEachFalsyValueOfProperty('recurrence', (patch) => {
+      expect(e.isRecurrent({ ...normalEvent, ...patch } as any)).to.be.false
+    })
+  })
+
+  it('isRecurrent() should return false when param has \'recurrence\' property of []', () => {
+    expect(e.isRecurrent({ recurrence: [] } as any)).to.be.false
+  })
+
+  it('isAllDay() should return true for an event from 00:00 to 00:00 of the next day', () => {
+    expect(e.isAllDay({
+      startDate: Moment(now).startOf('day'),
+      endDate: Moment(now).add(1, 'day').startOf('day')
+    } as any)).to.be.true
+  })
+
+  it('isAllDay() should return true for an event from 00:00 to 00:00 of the next nth days', () => {
+    const nthDays = [3, 5, 7]
+
+    nthDays.forEach((nthDay) => {
+      expect(e.isAllDay({
+        startDate: Moment(now).startOf('day'),
+        endDate: Moment(now).add(nthDay, 'day').startOf('day')
+      } as any)).to.be.true
+    })
+  })
+
+  it('isAllDay() should return false for an event from 00:00 to 00:00 of the same day', () => {
+    expect(e.isAllDay({
+      startDate: Moment(now).startOf('day'),
+      endDate: Moment(now).startOf('day')
+    } as any)).to.be.false
+  })
+
+  it('isAllDay() should return false for an event from 00:00 to 23:59:999 of the same day', () => {
+    expect(e.isAllDay({
+      startDate: Moment(now).startOf('day'),
+      endDate: Moment(now).endOf('day')
+    } as any)).to.be.false
+  })
+
+  it('isAllDay() should return false for an event that doesn\'t start at 00:00', () => {
+    expect(e.isAllDay({
+      startDate: Moment(now).startOf('day').add(1, 'hour'),
+      endDate: Moment(now).add(1, 'day').startOf('day').add(1, 'hour')
+    } as any)).to.be.false
+  })
+
+  it('originEventId() should pick out origin event id from generated id', () => {
+    const originId = recurrenceByMonth._id
+    const gen = new e.Generator(recurrenceByMonth as any)
+
+    for (let i = 0; i < 5; i++) {
+      const { _id } = gen.next().value!
+      expect(e.originEventId(_id)).to.equal(originId)
+    }
+  })
+
+  it('originEventId() should return the id as it is if the id is original', () => {
+    const originId = recurrenceByMonth._id
+    const gen = new e.Generator(recurrenceByMonth as any)
+
+    for (let i = 0; i < 5; i++) {
+      const { _id } = gen.next().value!
+      expect(e.originEventId(e.originEventId(_id))).to.equal(originId)
+    }
+  })
+})

--- a/test/apis/index.ts
+++ b/test/apis/index.ts
@@ -1,5 +1,4 @@
-import './event.spec'
-import './EventGenerator.spec'
+import './event'
 import './like.spec'
 import './my.spec'
 import './post.spec'

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -93,3 +93,17 @@ export function mock<T>(sdk: SDK) {
 export function restore(sdk: SDK) {
   sdk.fetch = new SDKFetch
 }
+
+export function forEachFalsyValueOfProperty(
+  prop: string,
+  f: (patch: { [key: string]: any }) => void
+) {
+  [{},
+   { [prop]: 0 },
+   { [prop]: '' },
+   { [prop]: null },
+   { [prop]: undefined },
+   { [prop]: false },
+   { [prop]: NaN }
+  ].forEach(f)
+}


### PR DESCRIPTION
...包括：

 - isRecurrent: 判断一个日程对象是否为重复日程
 - isAllDay: 判断一个日程是否为全天日程
 - originEventId: 重复日程的使用时，根据重复规则，常被生成多个日程实例，
   而每个这样的日程实例会带区别于原重复日程的 _id，通过该函数从生成的
   _id 获取原 _id