### PR TITLE
fix(tools/tasks/bundle): 兼容 rollup 的更新

### DIFF
--- a/tools/tasks/bundle.ts
+++ b/tools/tasks/bundle.ts
@@ -25,22 +25,20 @@ export function bundle (entry: string, output: string, name: string) {
     })
   ]
   rollup.rollup({
-    entry: entry,
+    input: entry,
     plugins: plugins
   })
     .then((bundle: any) => {
-      const code = bundle.generate({
+      return bundle.generate({
         format: 'umd',
-        moduleName: name,
+        name: name,
         globals: {
           lovefield: 'lf'
         },
         external: [ 'lovefield' ]
-      }).code
-
-      return code
+      })
     })
-    .then((code: string) => {
+    .then(({ code }: { code: string }) => {
       return write(path.resolve(process.cwd(), output), code)
     })
     .then(() => {


### PR DESCRIPTION
...包括：

 - rollup options.entry 改为 options.input 了
 - bundle.generate options.moduleName 改为 options.name 了
 - bundle.generate 返回 Promise<{ code, map }> 而不是 { code, map }