### PR TITLE
feat(sockets/): 令推送消息 type 字段到表名映射的逻辑 case-insensitive

### DIFF
--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -2,14 +2,13 @@ import 'rxjs/add/operator/concatMap'
 import 'rxjs/add/operator/do'
 import 'rxjs/add/operator/mapTo'
 import { Observable } from 'rxjs/Observable'
-import {
-  Database
-} from 'reactivedb'
+import { Database } from 'reactivedb'
 import { Net } from './Net'
-
 import { forEach } from './utils'
 import { SDKFetch } from './SDKFetch'
 import { SocketClient } from './sockets/SocketClient'
+import { TableInfoByMessageType } from './sockets/MapToTable'
+import tableAlias from './sockets/TableAlias'
 import { SchemaColl } from './utils/internalTypes'
 
 export const schemas: SchemaColl = []
@@ -20,7 +19,11 @@ export class SDK {
   net = new Net(schemas)
   fetch = new SDKFetch
 
-  socketClient: SocketClient = new SocketClient(this.fetch, this.net, schemas)
+  socketClient: SocketClient = new SocketClient(
+    this.fetch,
+    this.net,
+    new TableInfoByMessageType(schemas, tableAlias)
+  )
   database: Database
 
   lift: typeof Net.prototype.lift = (ApiResult: any): any => {

--- a/src/sockets/MapToTable.ts
+++ b/src/sockets/MapToTable.ts
@@ -1,0 +1,60 @@
+import Dirty from '../utils/Dirty'
+import { Dict, SchemaColl, TableInfo } from '../utils/internalTypes'
+import { SDKLogger } from '../utils/Logger'
+
+const byLowerCase = (ret: Dict<string>, x: string) => {
+  ret[x.toLowerCase()] = x
+  return ret
+}
+
+const collectPKNames = (schemas: SchemaColl) =>
+  schemas.reduce((ret, { schema, name }) => {
+    ret[name] = Dirty.getPKNameinSchema(schema)
+    return ret
+  }, {} as Dict<string>)
+
+const cutTrailingS = (msgType: string): string =>
+  msgType.slice(-1) === 's' ? msgType.slice(0, -1) : msgType
+
+export class TableInfoByMessageType {
+
+  private tabNameByLowerCase: Dict<string>
+  private tabAliasByLowerCase: Dict<string>
+  private pkNameByTabName: Dict<string>
+
+  constructor(schemas: SchemaColl, private tableAlias: Dict<string>) {
+    this.pkNameByTabName = collectPKNames(schemas)
+
+    const tabNames = Object.keys(this.pkNameByTabName)
+    const aliases = Object.keys(this.tableAlias)
+
+    this.tabNameByLowerCase = tabNames.reduce(byLowerCase, {})
+    this.tabAliasByLowerCase = aliases.reduce(byLowerCase, {})
+  }
+
+  private getTableName(msgType: string): string | undefined {
+    const msgtypes = msgType.toLowerCase()
+
+    const alias = this.tabAliasByLowerCase[msgtypes]
+    if (alias) {
+      return this.tableAlias[alias]
+    }
+
+    const msgtype = cutTrailingS(msgtypes)
+    return this.tabNameByLowerCase[msgtype]
+  }
+
+  getTableInfo(msgType: string): TableInfo | null {
+    const tabName = this.getTableName(msgType)
+
+    if (!tabName) {
+      SDKLogger.warn(`Table not found for message of type ${msgType}`)
+      return null
+    }
+
+    return {
+      tabName,
+      pkName: this.pkNameByTabName[tabName]
+    }
+  }
+}

--- a/src/sockets/TableAlias.ts
+++ b/src/sockets/TableAlias.ts
@@ -1,0 +1,14 @@
+/**
+ * 当 websocket 消息中类型字段的内容与目标表名不符，
+ * 请在这里添加转换规则。目标表名对应实际表名，注意查阅 schemas/
+ * 下的表名定义。
+ *
+ * 注：大小写区别，及单复数形式在名字末尾仅相差一个 's' 的情况
+ * 已做自动转换，无需在此处添加映射。
+ */
+export default {
+  Work: 'File',
+  ChatMessage: 'Activity',
+  Activities: 'Activity',
+  HomeActivities: 'Activity'
+}

--- a/src/utils/internalTypes.ts
+++ b/src/utils/internalTypes.ts
@@ -10,6 +10,15 @@ export type SchemaColl = {
   name: string
 }[]
 
+export type Dict<T> = {
+  [key: string]: T
+}
+
+export type TableInfo = {
+  tabName: string,
+  pkName: string
+}
+
 export interface PagingQuery {
   page: number,
   count: number

--- a/test/sockets/index.ts
+++ b/test/sockets/index.ts
@@ -1,2 +1,4 @@
 import './sockets.spec'
 import './eventParser.spec'
+import './tableAlias.spec'
+import './mapToTable.spec'

--- a/test/sockets/mapToTable.spec.ts
+++ b/test/sockets/mapToTable.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it } from 'tman'
+import { expect } from 'chai'
+import { TableInfoByMessageType } from '../../src/sockets/MapToTable'
+
+describe('TableInfoByMessageType spec', () => {
+
+  const mapToTable = new TableInfoByMessageType(
+    [
+      { name: 'Task', schema: { _id: { primaryKey: true } } },
+      { name: 'Event', schema: { _id: { primaryKey: true } } },
+      { name: 'Activity', schema: { _id: { primaryKey: true } } },
+      { name: 'CustomFieldLink', schema: { _id: { primaryKey: true } } },
+      { name: 'Alias', schema: { _id: { primaryKey: true } } }
+    ] as any,
+    {
+      'Alias': 'Task'
+    }
+  )
+
+  it('should map a normal message `type` or `Type` to its table info', () => {
+    const target = { pkName: '_id', tabName: 'Task' }
+    expect(mapToTable.getTableInfo('task')).to.deep.equal(target)
+    expect(mapToTable.getTableInfo('Task')).to.deep.equal(target)
+  })
+
+  it('should map a normal message `type`(case-insensitive) to its table info', () => {
+    const target = { pkName: '_id', tabName: 'CustomFieldLink' }
+    expect(mapToTable.getTableInfo('CustomfieldLink')).to.deep.equal(target)
+    expect(mapToTable.getTableInfo('customfieldLink')).to.deep.equal(target)
+    expect(mapToTable.getTableInfo('customfieldlink')).to.deep.equal(target)
+    expect(mapToTable.getTableInfo('CUSTOMFIELDLINK')).to.deep.equal(target)
+  })
+
+  it('should map a plural form message `types` or `Types` to its table info', () => {
+    const target = { pkName: '_id', tabName: 'Event' }
+    expect(mapToTable.getTableInfo('events')).to.deep.equal(target)
+    expect(mapToTable.getTableInfo('Events')).to.deep.equal(target)
+  })
+
+  it('should return null when no table info is defined for the message `type-ies`', () => {
+    expect(mapToTable.getTableInfo('activities')).to.be.null
+  })
+
+  it('should allow `alias`(case-insensitive) to take precedence', () => {
+    const target = { pkName: '_id', tabName: 'Task' }
+    expect(mapToTable.getTableInfo('alias')).to.deep.equal(target)
+    expect(mapToTable.getTableInfo('aliAs')).to.deep.equal(target)
+  })
+
+})

--- a/test/sockets/sockets.spec.ts
+++ b/test/sockets/sockets.spec.ts
@@ -25,7 +25,7 @@ describe('Socket handling Spec', () => {
     const spy = sinon.spy(logger, 'warn')
     const tx: any = 'Non-existent-table'
     yield socket.emit('new', tx, '', {})
-    expect(spy).to.be.calledWith(`Non-existent table: ${tx}`)
+    expect(spy).to.be.calledWith(`Table not found for message of type ${tx}`)
     spy.restore()
   })
 

--- a/test/sockets/tableAlias.spec.ts
+++ b/test/sockets/tableAlias.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it } from 'tman'
+import { expect } from 'chai'
+import { schemas } from '../../src/SDK'
+import { SchemaColl, clone } from '../index'
+
+import tableAlias from '../../src/sockets/TableAlias'
+
+describe('TableAlias spec', () => {
+
+  const schemasClone: SchemaColl = clone(schemas)
+
+  it('should map to existing tables', () => {
+    const existingTableNames = schemasClone.map(({ name }) => name)
+    const tableNamesByAlias = Object.keys(tableAlias).map((k) => tableAlias[k])
+
+    tableNamesByAlias.forEach((name) => {
+      expect(name).to.be.oneOf(existingTableNames)
+    })
+  })
+
+})

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,6 +1,7 @@
 'use strict'
 import { expect } from 'chai'
-import { forEach, SDK, capitalizeFirstLetter, SDKFetch } from './index'
+import { capitalize } from 'lodash'
+import { forEach, SDK, SDKFetch } from './index'
 import { MockFetch } from './mock/MockFetch'
 
 export function notInclude(collection: any[], ele: any) {
@@ -82,7 +83,7 @@ export function mock<T>(sdk: SDK) {
   return (m: T, schedule?: number | Promise<any>) => {
     methods.forEach(method => {
       sdk.fetch[method] = function(url: string, arg2?: any) {
-        const mockResult = mockFetch[`mock${capitalizeFirstLetter(method)}`](url, arg2)
+        const mockResult = mockFetch[`mock${capitalize(method)}`](url, arg2)
         mockResult.mockResponse.respond(m, schedule)
         return mockResult.request
       }


### PR DESCRIPTION
...同时，剥离从推送消息 type 字段到表名的映射的逻辑至 `TableInfoByMessageType` 类。

TODOs:
添加相关测试：
- [x] TableAlias 的测试
- [x] TableInfoByMessageType 类的测试