### PR TITLE
feat(schemas/Objectlink): 添加 parent, linked 字段以区分关联/被关联

### DIFF
--- a/src/schemas/ObjectLink.ts
+++ b/src/schemas/ObjectLink.ts
@@ -7,15 +7,18 @@ import {
   DetailObjectId
 } from 'teambition-types'
 
-export type ParentType = 'task' | 'post' | 'event' | 'work' | 'collection'
+// 下列任意两个类型（或同类型）的数据可以互相链接
+export type ParentType = 'task' | 'post' | 'event' | 'work' | 'collection' | 'entry'
 
 export interface ObjectLinkSchema {
   _id: ObjectLinkId
   _creatorId: UserId
   _parentId: DetailObjectId
   parentType: ParentType
-  linkedType: ParentType
+  parent: any
   _linkedId: DetailObjectId
+  linkedType: ParentType
+  linked: any
   created: string
   creator: ExecutorOrCreator
   title: string
@@ -51,8 +54,14 @@ const schema: SchemaDef<ObjectLinkSchema> = {
   data: {
     type: RDBType.OBJECT
   },
+  linked: {
+    type: RDBType.OBJECT
+  },
   linkedType: {
     type: RDBType.STRING
+  },
+  parent: {
+    type: RDBType.OBJECT
   },
   parentType: {
     type: RDBType.STRING


### PR DESCRIPTION
新增的 parent & linked 同 data 参数，存储的是 `关联的父对象` 和 `关联对象`

由于在关联与被关联中同一个对象的 _id 相同，导致前端在 ObjectLinkModel 中为了同步额外去 subscribeTo 从缓存中监听关联内容的变更会出问题。所以通过 parent & linked 来区分他们的关联联系。

ps: 其中 data 仍然保留为了移动端兼容，并且 linked 的内容和 data 一样