### PR TITLE
WIP feat(event/isAllDay): 为日程添加 isAllDay 属性

### DIFF
--- a/src/apis/event/index.ts
+++ b/src/apis/event/index.ts
@@ -10,4 +10,4 @@ export {
   EventSpan
 } from './request'
 
-export { originEventId, isAllDay, isRecurrent, allDayEventStartEndDate } from './utils'
+export { originEventId, isAllDay, isRecurrent, allDayEventStartEndDate, normAllDayEventStartEndDateUpdate } from './utils'

--- a/src/apis/event/index.ts
+++ b/src/apis/event/index.ts
@@ -10,4 +10,4 @@ export {
   EventSpan
 } from './request'
 
-export { originEventId, isAllDay, isRecurrent } from './utils'
+export { originEventId, isAllDay, isRecurrent, allDayEventStartEndDate } from './utils'

--- a/src/apis/event/utils/all-day.ts
+++ b/src/apis/event/utils/all-day.ts
@@ -1,0 +1,38 @@
+import { EventSchema } from '../../../schemas/event'
+
+const dateStrLen = 'YYYY-MM-DD'.length
+
+type AllDayInfo = {
+  isAllDay: boolean,
+  allDayStart: string,
+  allDayEnd: string
+}
+
+export const getAllDayInfo = (e: Readonly<EventSchema>): AllDayInfo | null => {
+  const { isAllDay, allDayStart, allDayEnd } = e
+
+  if (e.hasOwnProperty('isAllDay') &&
+      e.hasOwnProperty('allDayStart') &&
+      e.hasOwnProperty('allDayEnd')
+  ) {
+    return { isAllDay, allDayStart, allDayEnd }
+  } else {
+    return null
+  }
+}
+
+export const generateStartEndDate = (info: AllDayInfo): { startDate: string, endDate: string } => {
+  const start = new Date(info.allDayStart.slice(0, dateStrLen))
+  const end = new Date(info.allDayEnd.slice(0, dateStrLen))
+
+  // 获得当前时区的具体开始时间和结束时间，兼容 legacy 模式的全天日程定义。
+  const startDate = new Date(start.getFullYear(), start.getMonth(), start.getDate())
+  const endDate = new Date(end.getFullYear(), end.getMonth(), end.getDate())
+
+  return {
+    startDate: startDate.toISOString(),
+    endDate: endDate.toISOString()
+  }
+}
+
+export const isAllDay = (info: AllDayInfo): boolean => info.isAllDay

--- a/src/apis/event/utils/index.ts
+++ b/src/apis/event/utils/index.ts
@@ -1,11 +1,14 @@
-import { EventSchema } from '../../schemas/Event'
+import { EventSchema } from '../../../schemas/Event'
 import { EventId } from 'teambition-types'
+import { SDKLogger } from '../../../utils/Logger'
+
+import * as ad from './all-day'
 
 /**
  * 判断一个日程对象是否为重复日程。
  * 注意：有重复规则，但仅能推导得零个可用时间点的日程，会返回 true。
  */
-export const isRecurrent = (event: EventSchema) =>
+export const isRecurrent = (event: Readonly<EventSchema>) =>
   !!event.recurrence && event.recurrence.length > 0
 
 const msPerDay = 24 * 60 * 60 * 1000
@@ -15,11 +18,33 @@ const epochTime = new Date(1970, 0, 1).valueOf()
 
 /**
  * 判断一个日程是否为全天日程。
- * 目前全天日程的定义为，开始时间为零点，结束时间为第二天零点，或
+ */
+export const isAllDay = (e: Readonly<EventSchema>): boolean => {
+  const snippet = ad.getAllDayInfo(e)
+  let currentResult: boolean
+  const legacyResult = isAllDayLegacy(e)
+
+  if (snippet) {
+    currentResult = ad.isAllDay(snippet)
+
+    if (currentResult !== legacyResult) { // for debugging purpose
+      SDKLogger.warn('isAllDay migration incompatibility:', {
+        current: e.isAllDay,
+        legacy: legacyResult
+      })
+    }
+    return currentResult
+  } else {
+    return legacyResult
+  }
+}
+
+/**
+ * LEGACY 全天日程的定义：开始时间为零点，结束时间为第二天零点，或
  * 接下来第 n 天零点，的日程。
  * 注意：零点判断根据当地时区得。
  */
-export const isAllDay = (e: EventSchema): boolean => {
+const isAllDayLegacy = (e: Readonly<EventSchema>): boolean => {
   const startTime = new Date(e.startDate).valueOf()
 
   if ((startTime - epochTime) % msPerDay !== 0) {
@@ -29,6 +54,16 @@ export const isAllDay = (e: EventSchema): boolean => {
   const duration = new Date(e.endDate).valueOf() - startTime
 
   return duration > 0 && duration % msPerDay === 0
+}
+
+export const allDayEventStartEndDate = (e: Readonly<EventSchema>) => {
+  const snippet = ad.getAllDayInfo(e)
+
+  if (!snippet) { // pass through
+    return { startDate: e.startDate, endDate: e.endDate }
+  }
+
+  return ad.generateStartEndDate(snippet)
 }
 
 /**

--- a/src/apis/event/utils/index.ts
+++ b/src/apis/event/utils/index.ts
@@ -56,7 +56,9 @@ const isAllDayLegacy = (e: Readonly<EventSchema>): boolean => {
   return duration > 0 && duration % msPerDay === 0
 }
 
-export const allDayEventStartEndDate = (e: Readonly<EventSchema>) => {
+type StartEndDate = Pick<EventSchema, 'startDate' | 'endDate'>
+
+export const allDayEventStartEndDate = (e: Readonly<EventSchema>): StartEndDate => {
   const snippet = ad.getAllDayInfo(e)
 
   if (!snippet) { // pass through
@@ -64,6 +66,29 @@ export const allDayEventStartEndDate = (e: Readonly<EventSchema>) => {
   }
 
   return ad.generateStartEndDate(snippet)
+}
+
+export const normAllDayEventStartEndDateUpdate = (attrs: Readonly<StartEndDate>) => {
+  const startDate = new Date(attrs.startDate)
+  const endDate = new Date(attrs.endDate)
+
+  const normedStartDate = new Date(Date.UTC(
+    startDate.getFullYear(),
+    startDate.getMonth(),
+    startDate.getDate()
+  )).toISOString()
+  const normedEndDate = new Date(Date.UTC(
+    endDate.getFullYear(),
+    endDate.getMonth(),
+    endDate.getDate()
+  )).toISOString()
+
+  return {
+    startDate: normedStartDate,
+    endDate: normedEndDate,
+    allDayStart: normedStartDate.slice(0, 10),
+    allDayEnd: normedEndDate.slice(0, 10)
+  }
 }
 
 /**

--- a/src/schemas/Event.ts
+++ b/src/schemas/Event.ts
@@ -24,6 +24,9 @@ export interface EventSchema {
   startDate: string
   endDate: string
   untilDate: string
+  isAllDay: boolean
+  allDayStart: string
+  allDayEnd: string
   involveMembers: string []
   _projectId: ProjectId
   _scenariofieldconfigId?: ScenarioFieldConfigId
@@ -69,6 +72,12 @@ const schema: SchemaDef<EventSchema> = {
   _sourceId: {
     type: RDBType.STRING
   },
+  allDayStart: {
+    type: RDBType.STRING
+  },
+  allDayEnd: {
+    type: RDBType.STRING
+  },
   attachmentsCount: {
     type: RDBType.NUMBER
   },
@@ -101,6 +110,9 @@ const schema: SchemaDef<EventSchema> = {
   },
   involveMembers: {
     type: RDBType.LITERAL_ARRAY
+  },
+  isAllDay: {
+    type: RDBType.BOOLEAN
   },
   isArchived: {
     type: RDBType.BOOLEAN

--- a/test/apis/event/utils.spec.ts
+++ b/test/apis/event/utils.spec.ts
@@ -37,43 +37,93 @@ describe('Event-related util functions', () => {
     expect(e.isRecurrent({ recurrence: [] } as any)).to.be.false
   })
 
-  it('isAllDay() should return true for an event from 00:00 to 00:00 of the next day', () => {
+  it('isAllDay() should return the value of field `isAllDay`, whenever it is true/false, even if the LEGACY mode reports otherwise', () => {
     expect(e.isAllDay({
-      startDate: Moment(now).startOf('day'),
-      endDate: Moment(now).add(1, 'day').startOf('day')
+      isAllDay: true,
+      allDayStart: '2017-10-30',
+      allDayEnd: '2017-10-31'
+    } as any)).to.be.true
+
+    expect(e.isAllDay({
+      isAllDay: false,
+      allDayStart: '',
+      allDayEnd: ''
+    } as any)).to.be.false
+
+    expect(e.isAllDay({
+      isAllDay: true,
+      allDayStart: '2017-10-30',
+      allDayEnd: '2017-10-31',
+      startDate: Moment(now).toISOString(),
+      endDate: Moment(now).add(1, 'hour').toISOString()
+    } as any)).to.be.true
+
+    expect(e.isAllDay({
+      isAllDay: false,
+      allDayStart: '',
+      allDayEnd: '',
+      startDate: Moment(now).startOf('day').toISOString(),
+      endDate: Moment(now).add(1, 'day').startOf('day').toISOString()
+    } as any)).to.be.false
+  })
+
+  it('LEGACY isAllDay() should return true for an event from 00:00 to 00:00 of the next day', () => {
+    expect(e.isAllDay({
+      startDate: Moment(now).startOf('day').toISOString(),
+      endDate: Moment(now).add(1, 'day').startOf('day').toISOString()
     } as any)).to.be.true
   })
 
-  it('isAllDay() should return true for an event from 00:00 to 00:00 of the next nth days', () => {
+  it('LEGACY isAllDay() should return true for an event from 00:00 to 00:00 of the next nth days', () => {
     const nthDays = [3, 5, 7]
 
     nthDays.forEach((nthDay) => {
       expect(e.isAllDay({
-        startDate: Moment(now).startOf('day'),
-        endDate: Moment(now).add(nthDay, 'day').startOf('day')
+        startDate: Moment(now).startOf('day').toISOString(),
+        endDate: Moment(now).add(nthDay, 'day').startOf('day').toISOString()
       } as any)).to.be.true
     })
   })
 
-  it('isAllDay() should return false for an event from 00:00 to 00:00 of the same day', () => {
+  it('LEGACY isAllDay() should return false for an event from 00:00 to 00:00 of the same day', () => {
     expect(e.isAllDay({
-      startDate: Moment(now).startOf('day'),
-      endDate: Moment(now).startOf('day')
+      startDate: Moment(now).startOf('day').toISOString(),
+      endDate: Moment(now).startOf('day').toISOString()
     } as any)).to.be.false
   })
 
-  it('isAllDay() should return false for an event from 00:00 to 23:59:999 of the same day', () => {
+  it('LEGACY isAllDay() should return false for an event from 00:00 to 23:59:999 of the same day', () => {
     expect(e.isAllDay({
-      startDate: Moment(now).startOf('day'),
-      endDate: Moment(now).endOf('day')
+      startDate: Moment(now).startOf('day').toISOString(),
+      endDate: Moment(now).endOf('day').toISOString()
     } as any)).to.be.false
   })
 
-  it('isAllDay() should return false for an event that doesn\'t start at 00:00', () => {
+  it('LEGACY isAllDay() should return false for an event that doesn\'t start at 00:00', () => {
     expect(e.isAllDay({
-      startDate: Moment(now).startOf('day').add(1, 'hour'),
-      endDate: Moment(now).add(1, 'day').startOf('day').add(1, 'hour')
+      startDate: Moment(now).startOf('day').add(1, 'hour').toISOString(),
+      endDate: Moment(now).add(1, 'day').startOf('day').add(1, 'hour').toISOString()
     } as any)).to.be.false
+  })
+
+  it('allDayEventStartEndDate() should return orginal startDate/endDate for object without allday info', () => {
+    const startEndDate = {
+      startDate: Moment(now).startOf('day').toISOString(),
+      endDate: Moment(now).add(1, 'day').startOf('day').toISOString()
+    }
+    expect(e.allDayEventStartEndDate(startEndDate as any)).to.deep.equal(startEndDate)
+  })
+
+  it('allDayEventStartEndDate() should return valid allday event startDate/endDate when provided with allday info', () => {
+    const allDayInfos = [1, 2, 3].map((nth) => ({
+      isAllDay: true,
+      allDayStart: '2017-10-10',
+      allDayEnd: '2017-10-1' + nth
+    }))
+
+    allDayInfos.forEach((allDayInfo) => {
+      expect(e.isAllDay(e.allDayEventStartEndDate(allDayInfo as any) as any)).to.be.true
+    })
   })
 
   it('originEventId() should pick out origin event id from generated id', () => {

--- a/test/apis/event/utils.spec.ts
+++ b/test/apis/event/utils.spec.ts
@@ -126,6 +126,28 @@ describe('Event-related util functions', () => {
     })
   })
 
+  it('normAllDayEventStartEndDateUpdate() should return normalized date info', () => {
+    expect(e.normAllDayEventStartEndDateUpdate({
+      startDate: '2017-10-31T16:00:00.000-08:00',
+      endDate: '2017-11-01T16:00:00.000-08:00'
+    })).to.deep.equal({
+      startDate: '2017-11-01T00:00:00.000Z',
+      endDate: '2017-11-02T00:00:00.000Z',
+      allDayStart: '2017-11-01',
+      allDayEnd: '2017-11-02'
+    })
+
+    expect(e.normAllDayEventStartEndDateUpdate({
+      startDate: '2017-10-31T16:00:00.000-08:00',
+      endDate: '2017-11-03T16:00:00.000-08:00'
+    })).to.deep.equal({
+      startDate: '2017-11-01T00:00:00.000Z',
+      endDate: '2017-11-04T00:00:00.000Z',
+      allDayStart: '2017-11-01',
+      allDayEnd: '2017-11-04'
+    })
+  })
+
   it('originEventId() should pick out origin event id from generated id', () => {
     const originId = recurrenceByMonth._id
     const gen = new e.Generator(recurrenceByMonth as any)


### PR DESCRIPTION
...及相关属性：allDayStart, allDayEnd。

更新 EventSchema。

更新日程工具函数中 isAllDay 的逻辑，优先通过日程模型上的 isAllDay 属性
判断，仅当日程模型上找不到有布尔值的 isAllDay 属性，使用原逻辑通过开始
时间和结束时间来判断。并添加相关测试。

添加为全天日程生成当地时区遵循原全天判断规则的startDate/endDate的函数