### PR TITLE
chore(dependency): 升级 typescript 到 2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,6 @@
     "tslib": "^1.7.1",
     "tslint": "^5.7.0",
     "tslint-eslint-rules": "^4.1.1",
-    "typescript": "^2.5.3"
+    "typescript": "^2.6.2"
   }
 }

--- a/src/SDKFetch.ts
+++ b/src/SDKFetch.ts
@@ -230,8 +230,8 @@ export class SDKFetch {
     return { ...this.options }
   }
 
-  private setOptionsPerRequest<T>(
-    http: Http<T | HttpResponseWithHeaders<T>>,
+  private setOptionsPerRequest(
+    http: Http<any>,
     fetchOptions: SDKFetchOptions
   ): void {
     let headers: any

--- a/tools/tasks/test.ts
+++ b/tools/tasks/test.ts
@@ -28,7 +28,7 @@ function watch (paths: string[]) {
       })
       return () => fileWatcher.close()
     }))
-    .debounceTime(300)
+    .debounceTime(500)
 }
 
 watch(['spec-js'])

--- a/yarn.lock
+++ b/yarn.lock
@@ -2594,9 +2594,9 @@ type-detect@^4.0.0:
   version "4.0.3"
   resolved "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
 
-typescript@^2.5.3:
-  version "2.5.3"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"
+typescript@^2.6.2:
+  version "2.6.2"
+  resolved "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
 
 uglify-js@^2.6:
   version "2.8.28"


### PR DESCRIPTION
...并根据类型报错修改相关代码。

另：调长测试 watch 模式里的 debounceTime 到 500ms，降低 tsc 新 watch
mode 导致的“重新编译已完成”的误判概率，避免 runTman 在重新编译尚未完成，
而文件更新正在持续输出的情况下，被多次调用，导致某些测试失败。