### PR TITLE
issue(sockets/EventMaps): 支持批量“更新”/“删除”消息

### DIFF
--- a/mock/socket.ts
+++ b/mock/socket.ts
@@ -15,7 +15,8 @@ export interface RequestEvent {
 export type SocketEventType = 'activity' | 'message' | 'project' | 'task' | 'subtask' |
                               'post' | 'work' | 'tasklist' | 'stage' |
                               'collection' | 'tag' | 'user' | 'preference' | 'member' |
-                              'event' | 'subscriber' | 'feedback' | 'homeActivity' | 'works'
+                              'event' | 'subscriber' | 'feedback' | 'homeActivity' | 'works' |
+                              'tasks'
 
 export interface ToPromiseObject {
   toPromise: () => Promise<any>

--- a/src/sockets/EventMaps.ts
+++ b/src/sockets/EventMaps.ts
@@ -42,10 +42,9 @@ export const handleMsgToDb = (
       if (dirtyStream) {
         return dirtyStream
       }
-      return dbMethod.call(db, tableName, {
-        ...data,
-        [pkName]: id
-      })
+      return dbMethod.call(db, tableName,
+        Array.isArray(data) ? data : { ...data, [pkName]: id }
+      )
     case 'destroy':
       return dbMethod.call(db, tableName, {
         where: { [pkName]: id }

--- a/src/sockets/EventMaps.ts
+++ b/src/sockets/EventMaps.ts
@@ -51,7 +51,7 @@ export const handleMsgToDb = (
       })
     case 'remove':
       return dbMethod.call(db, tableName, {
-        where: { [pkName]: data }
+        where: Array.isArray(data) ? { [pkName]: { $in: data } } : { [pkName]: data }
       })
     default:
       return Observable.of(null)

--- a/test/sockets/sockets.spec.ts
+++ b/test/sockets/sockets.spec.ts
@@ -70,6 +70,27 @@ describe('Socket handling Spec', () => {
       })
   })
 
+  it('should do db:remove for all the PKs to be deleted in { e: ":remove:{modelType}s/{boundToObjectId}", d: "[pk1, pk2, ...]"}', function* () {
+    const _projectId = '597fdea5528664cd3c81ebd9'
+    const tasks = [
+      { isDone: false, _id: '5a17b9a5a58dd8a0cddec5e6', _projectId },
+      { isDone: false, _id: '5a17b9a5a58dd8a0cddec5e7', _projectId },
+      { isDone: false, _id: '5a17b9a5a58dd8a0cddec5e8', _projectId }
+    ]
+
+    yield sdk.database.upsert('Task', tasks)
+
+    yield socket.emit('remove', 'tasks', _projectId, tasks.map(({ _id }) => _id).slice(0, 2))
+
+    yield sdk.database.get('Task')
+      .values()
+      .do((rs) => {
+        expect(rs).to.have.lengthOf(1)
+        const [r] = rs
+        expectToDeepEqualForFieldsOfTheExpected(r, tasks[2])
+      })
+  })
+
   it('should do db:remove on { e: ":destroy:{modelType}/{modelId}", d: "" }', function* () {
     const modelId = '587ee5510f399a3a37e0e182'
     const postSample = {


### PR DESCRIPTION
批量更新：`{ e: ":change:{modelType}s/{boundToObjectId}", d: "[update1, update2, ...]" }`，其中 `update1, update2` 等为含相应 model 类型主键信息及更新字段信息的对象。

批量删除：`{ e: ":remove:{modelType}s/{boundToObjectId}", d: "[pk1, pk2, ...]" }`，其中 `pk1, pk2` 等对应要删除的 model 的主键。