### PR TITLE
feat(cache-revalidate): 试验为 Task 表的接口用户提供懒更新的功能

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://github.com/teambition/teambition-sdk#readme",
   "peerDependencies": {
-    "reactivedb": "~0.9.13",
+    "reactivedb": "~0.9.15",
     "rrule": "2.2.0",
     "rxjs": "^5.2.0",
     "snapper-consumer": "^1.3.6",
@@ -65,7 +65,7 @@
     "moment": "^2.18.1",
     "node-watch": "^0.5.5",
     "nyc": "^11.2.1",
-    "reactivedb": "~0.9.13",
+    "reactivedb": "~0.9.15",
     "rollup": "^0.51.0",
     "rollup-plugin-alias": "^1.3.1",
     "rollup-plugin-commonjs": "^8.2.1",

--- a/src/schemas/Task.ts
+++ b/src/schemas/Task.ts
@@ -85,7 +85,11 @@ export interface TaskSchema {
   }
 }
 
-const schema: SchemaDef<TaskSchema> = {
+interface TaskSchemaRevalidateEnabled extends TaskSchema {
+  __cacheIsInvalid__: boolean
+}
+
+const schema: SchemaDef<TaskSchemaRevalidateEnabled> = {
   _creatorId: {
     type: RDBType.STRING
   },
@@ -284,6 +288,9 @@ const schema: SchemaDef<TaskSchema> = {
   },
   workTime: {
     type: RDBType.OBJECT
+  },
+  __cacheIsInvalid__: {
+    type: RDBType.BOOLEAN
   }
 }
 

--- a/src/sockets/EventMaps.ts
+++ b/src/sockets/EventMaps.ts
@@ -53,6 +53,11 @@ export const handleMsgToDb = (
       return dbMethod.call(db, tableName, {
         where: Array.isArray(data) ? { [pkName]: { $in: data } } : { [pkName]: data }
       })
+    case 'refresh':
+      dirtyStream = Dirty.handleRefreshMessage(id, tableName, data, db)
+      if (dirtyStream) {
+        return dirtyStream
+      }
     default:
       return Observable.of(null)
   }

--- a/src/utils/Dirty.ts
+++ b/src/utils/Dirty.ts
@@ -20,6 +20,14 @@ export class Dirty {
     return tasks
   }
 
+  handleRefreshMessage(id: string, type: string, _: any, db: Database): Observable<any> | null {
+    if (type === 'Task') {
+      return db.update(type, { _stageId: id }, { __cacheIsInvalid__: true })
+    } else {
+      return null
+    }
+  }
+
   handleSocketMessage(id: string, type: string, data: any, db: Database): Observable<any> | null {
     const methods = [ '_handleLikeMessage', '_handleTaskUpdateFromSocket', '_handleMessage']
     let signal: Observable<any> | null = null

--- a/yarn.lock
+++ b/yarn.lock
@@ -1993,9 +1993,9 @@ rc@^1.1.6:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-reactivedb@~0.9.13:
-  version "0.9.13"
-  resolved "https://registry.npmjs.org/reactivedb/-/reactivedb-0.9.13.tgz#8954d728d35c97fc702c20eb0a66f8427c8f0184"
+reactivedb@~0.9.15:
+  version "0.9.15"
+  resolved "https://registry.npmjs.org/reactivedb/-/reactivedb-0.9.15.tgz#3f509fd50d6b56826108fb26d19b6f50745e5e13"
   dependencies:
     "@types/lovefield" "^2.0.32"
     lovefield "2.1.12"


### PR DESCRIPTION
...通常来讲，SDK 管理的数据会通过 websocket “实时”与后端同步，但并不是
所有的更新都需要及时同步过来（导致不必要的数据传输）。我们尝试接收后端
发来的 cache 过期的提示，并将相关条目标为 { __cacheIsInvalid__: true }。
SDK 接口在使用到这些条目时，会知道需要更新数据。目前默认将接口中对应的
request 重新请求一次，这在很多时候应该都是不够准确的。接下来再在使用中
探索。