### PR TITLE
fix(type): 新添 VisibleOption 代替定义错误的 Visibility

### DIFF
--- a/src/apis/post/create.ts
+++ b/src/apis/post/create.ts
@@ -2,14 +2,14 @@ import { Observable } from 'rxjs/Observable'
 import { SDK } from '../../SDK'
 import { SDKFetch } from '../../SDKFetch'
 import { PostModeOptions, PostSchema } from '../../schemas/Post'
-import { ProjectId, Visibility, FileId, UserId, TagId } from 'teambition-types'
+import { ProjectId, VisibleOption, FileId, UserId, TagId } from 'teambition-types'
 
 export interface CreatePostOptions {
   _projectId: ProjectId
   title: string
   content: string
   postMode?: PostModeOptions
-  visiable?: Visibility
+  visible?: VisibleOption
   attachments?: FileId[]
   involveMembers?: UserId[]
   tagIds?: TagId[]
@@ -27,7 +27,7 @@ declare module '../../SDKFetch' {
   }
 }
 
-export function createPost (this: SDK, options: CreatePostOptions): Observable<PostSchema> {
+export function createPost(this: SDK, options: CreatePostOptions): Observable<PostSchema> {
   return this.lift({
     request: this.fetch.createPost(options),
     tableName: 'Post',

--- a/src/schemas/Entry.ts
+++ b/src/schemas/Entry.ts
@@ -3,7 +3,7 @@ import {
   EntryCategoryId,
   ProjectId,
   UserId,
-  Visibility,
+  VisibleOption,
   TagId
 } from 'teambition-types'
 
@@ -18,7 +18,7 @@ export interface EntryData {
   amount: number
   status: string
   involveMembers: string[]
-  visible: Visibility
+  visible: VisibleOption
   tagIds: TagId[]
   created: string
   updated: string

--- a/src/schemas/Event.ts
+++ b/src/schemas/Event.ts
@@ -1,7 +1,7 @@
 import { SchemaDef, RDBType, Relationship } from 'reactivedb/interface'
 import { schemaColl } from './schemas'
 import {
-  Visibility,
+  VisibleOption,
   EventId,
   UserId,
   ProjectId,
@@ -36,7 +36,7 @@ export interface EventSchema {
   recurrence: string[]
   reminders: string[]
   isArchived: boolean
-  visible: Visibility
+  visible: VisibleOption
   isDeleted: boolean
   created: string
   updated: string

--- a/src/schemas/File.ts
+++ b/src/schemas/File.ts
@@ -7,7 +7,7 @@ import {
   TagId,
   ProjectId,
   UserId,
-  Visibility,
+  VisibleOption,
   ExecutorOrCreator
 } from 'teambition-types'
 
@@ -25,7 +25,7 @@ export interface FileSchema {
   _creatorId: UserId
   creator: ExecutorOrCreator
   tagIds: TagId[]
-  visible: Visibility
+  visible: VisibleOption
   downloadUrl: string
   thumbnail: string
   thumbnailUrl: string

--- a/src/schemas/Task.ts
+++ b/src/schemas/Task.ts
@@ -1,5 +1,5 @@
 import { RDBType, Relationship, SchemaDef } from 'reactivedb/interface'
-import { CustomFieldValue, ExecutorOrCreator, Reminder, Visibility } from 'teambition-types'
+import { CustomFieldValue, ExecutorOrCreator, Reminder, VisibleOption } from 'teambition-types'
 import {
   ProjectId,
   ScenarioFieldConfigId,
@@ -32,7 +32,7 @@ export interface TaskSchema {
   isDeleted: boolean
   created: string
   updated: string
-  visible: Visibility
+  visible: VisibleOption
   _sprintId?: SprintId
   _stageId: StageId
   _creatorId: UserId

--- a/src/teambition.ts
+++ b/src/teambition.ts
@@ -76,7 +76,7 @@ declare module 'teambition-types' {
   export type TaskPriority = 0 | 1 | 2
   export type TaskScenarioFieldIcon = 'task' | 'requirement' | 'bug' | 'hr' | 'resource' | 'order' | 'salesLead' | 'subtask'
   export type TeamMemberStatus = 'in' | 'quited' | 'disabled'
-  export type Visibility = 'all' | 'members' | 'organization' | 'project'
+  export type VisibleOption = 'members' | 'involves'
 }
 
 declare module 'teambition-types' {


### PR DESCRIPTION
VisibleOption 的枚举值为 `'members' | 'involves'`。

Visibility 定义里 `'all' | 'organization' | 'project'` 为 ProjectSchema 上的 visibility 字段独有，其类型已经写在 `ProjectSchema['visibility']` 上了。而真正用到 Visibility 类型的地方，其值都对应 `'members' | 'involves'`。
    
所以，修改所有当前使用 Visibility 但其实指 `'members' | 'involves'` 的地方为 VisibleOption，避免与 Visibility 冲突。暂时移除 Visibility，以后需要将 ProjectSchema 上的类型单独提取出来时，再定义 Visibility。

...resolves #431