### PR TITLE
fix(SDKFetch): 修复其 includeHeaders 选项在实际项目中的有效性

### DIFF
--- a/src/Net/Http.ts
+++ b/src/Net/Http.ts
@@ -17,7 +17,7 @@ export interface HttpErrorMessage {
   body?: any
 }
 
-export interface HttpResponseWithHeaders<T> {
+export interface HttpResponseWithHeaders<T = any> {
   headers: any,
   body: T
 }
@@ -45,20 +45,17 @@ export const createMethod = (method: AllowedHttpMethod) => (params: MethodParams
       crossDomain: typeof _opts.crossDomain !== 'undefined' ? !!_opts.crossDomain : true
     })
       .map(value => {
-        const resp = value.response
-        try {
-          const respBody = JSON.parse(resp)
-          if (!includeHeaders) {
-            const respHeaders = parseHeaders(value.xhr.getAllResponseHeaders())
-            return {
-              headers: respHeaders,
-              body: respBody
-            }
-          }
+        const respBody = value.response
+        if (!includeHeaders) {
           return respBody
-        } catch (e) {
-          return resp
         }
+        let respHeaders: any
+        try {
+          respHeaders = parseHeaders(value.xhr.getAllResponseHeaders())
+        } catch (e) {
+          respHeaders = null
+        }
+        return { headers: respHeaders, body: respBody }
       })
       .catch((e: AjaxError) => {
         const headers = e.xhr.getAllResponseHeaders()


### PR DESCRIPTION
...原来的实现对 Observable.ajax 的使用中，误把其已经 JSON.parse 过的
AjaxResponse.response 再做了一次 JSON.parse，导致 throw 并总是走 catch
逻辑，间接导致 includeHeaders 选项失效。

Note: 当 responseType 为 json，Observable.ajax 会自动把 JSON.parse 后
的结果给其 response 字段。