### PR TITLE
fix(dependency): 将 reactivedb 版本降回 0.9.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://github.com/teambition/teambition-sdk#readme",
   "peerDependencies": {
-    "reactivedb": "~0.10.2",
+    "reactivedb": "~0.9.13",
     "rrule": "2.2.0",
     "rxjs": "^5.2.0",
     "snapper-consumer": "^1.3.6",
@@ -65,7 +65,7 @@
     "moment": "^2.18.1",
     "node-watch": "^0.5.8",
     "nyc": "^11.2.1",
-    "reactivedb": "~0.10.2",
+    "reactivedb": "~0.9.13",
     "rollup": "^0.58.2",
     "rollup-plugin-alias": "^1.3.1",
     "rollup-plugin-commonjs": "^8.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2067,9 +2067,9 @@ rc@1.2.5:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-reactivedb@~0.10.2:
-  version "0.10.2"
-  resolved "https://registry.npmjs.org/reactivedb/-/reactivedb-0.10.2.tgz#297c0b05599b5c4fab4f7bf6c82cb81e50915b43"
+reactivedb@~0.9.13:
+  version "0.9.16"
+  resolved "https://registry.npmjs.org/reactivedb/-/reactivedb-0.9.16.tgz#3d53b156663bb6d1e79e4246240a3781c612e7e6"
   dependencies:
     "@types/lovefield" "^2.1.1"
     lovefield "2.1.12"


### PR DESCRIPTION
...避免 reactivedb 0.10.2 版本中使用的新版 rxjs 依赖在用户代码中无法编
译。

...应该不会有功能上的影响。