### PR TITLE
feat(Net): 为 ApiResult.query 添加 fields 字段的支持

### DIFF
--- a/src/Net/Net.ts
+++ b/src/Net/Net.ts
@@ -27,11 +27,29 @@ export enum CacheStrategy {
 
 export interface ApiResult<T, U extends CacheStrategy> {
   request: Observable<T> | Observable<T[]>
-  query: Query<T>
+  /**
+   * 使用 fields 指定需要查询的字段，where 指定查询条件，
+   * orderBy 指定结果排序规则。更多支持的选项请见具体类型定义。
+   */
+  query: Query<T> & { fields?: Array<keyof T> }
   tableName: string
   cacheValidate: U
   required?: (keyof T)[]
+  /**
+   * 指定需要关联其他数据模型（M）查询获得的字段，以及
+   * 该字段对应值应该包含的 M 里的字段，如：
+   * {
+   *   creator: ['_id', 'name'],
+   *   executor: ['_id', 'name', 'avatarUrl']
+   * }
+   */
   assocFields?: AssocField<T>
+  /**
+   * 指定不希望出现在查询结果里的字段。
+   * 注：ApiResult.query.fields 中指定的希望出现的字段
+   * 拥有更高优先级，除非 ApiResult.query.fields 未定义
+   * 或为空（[]）。
+   */
   excludeFields?: string[]
   padding?: (missedId: string) => Observable<T | null>
 }
@@ -76,6 +94,15 @@ export type BufferObject = CUDBufferObject | SocketCUDBufferObject | SelectorBuf
 const dbGetWithSelfJoinEnabled =
   <T>(db: Database, table: string, query: Query<T>): QueryToken<T> => {
     return db.get(table, query, JoinMode.explicit)
+  }
+
+const fieldsPred =
+  (include: string[] = [], exclude: string[] = []) => {
+    if (include.length > 0) {
+      return (field: string) => include.indexOf(field) >= 0
+    } else {
+      return (field: string) => exclude.indexOf(field) < 0
+    }
   }
 
 export class Net {
@@ -332,21 +359,20 @@ export class Net {
       assocFields,
       excludeFields
     } = result as ApiResult<T, CacheStrategy>
+
     const preDefinedFields = this.fields.get(tableName)
     if (!preDefinedFields) {
       throw new TypeError(`table: ${tableName} is not defined`)
     }
-    const fields: string[] = []
-    if (assocFields) {
-      fields.push(assocFields as any)
+
+    const fieldNames = preDefinedFields
+      .filter(fieldsPred(query.fields, excludeFields))
+
+    const q: Query<T> = {
+      ...query,
+      fields: assocFields ? [assocFields as any, ...fieldNames] : fieldNames
     }
-    const set = new Set(excludeFields)
-    forEach(this.fields.get(tableName), f => {
-      if (!set.has(f)) {
-        fields.push(f)
-      }
-    })
-    const q: Query<T> = { ...query, fields }
+
     return { request, q, cacheValidate, tableName }
   }
 }

--- a/src/apis/post/getByTagId.ts
+++ b/src/apis/post/getByTagId.ts
@@ -1,5 +1,5 @@
 import { Observable } from 'rxjs/Observable'
-import { Query, QueryToken, OrderDescription } from 'reactivedb'
+import { QueryToken, OrderDescription } from 'reactivedb'
 import { SDK, CacheStrategy } from '../../SDK'
 import { TagId } from 'teambition-types'
 import { PostSchema } from '../../schemas/Post'
@@ -43,7 +43,7 @@ export function getByTagId (
   const urlQuery = queryPair.forUrl as GetPostsByTagIdUrlQuery
   const { skip, limit } = queryPair.forSql
 
-  const selectStmt: Query<PostSchema> = {
+  const selectStmt = {
     where: {
       isArchived: false,
       tagIds: {

--- a/src/apis/post/getMyProjects.ts
+++ b/src/apis/post/getMyProjects.ts
@@ -1,4 +1,4 @@
-import { Query, QueryToken } from 'reactivedb'
+import { QueryToken } from 'reactivedb'
 import { SDK, CacheStrategy } from '../../SDK'
 import { ProjectId, UserId } from 'teambition-types'
 import { PostSchema } from '../../schemas/Post'
@@ -16,7 +16,7 @@ export function getMyProjectPosts (
   const urlQuery = queryPair.forUrl as GetPostsUrlQuery<'my'>
   const { skip, limit } = queryPair.forSql
 
-  const selectStmt: Query<PostSchema> = {
+  const selectStmt = {
     where: {
       _projectId,
       isArchived: false,

--- a/src/apis/post/getProjects.ts
+++ b/src/apis/post/getProjects.ts
@@ -1,5 +1,5 @@
 import { Observable } from 'rxjs/Observable'
-import { QueryToken, OrderDescription, Query } from 'reactivedb'
+import { QueryToken, OrderDescription } from 'reactivedb'
 import { SDK, CacheStrategy } from '../../SDK'
 import { SDKFetch } from '../../SDKFetch'
 import { ProjectId } from 'teambition-types'
@@ -48,7 +48,7 @@ export function getAllProjectPosts (
   const urlQuery = queryPair.forUrl as GetPostsUrlQuery<'all'>
   const { skip, limit } = queryPair.forSql
 
-  const selectStmt: Query<PostSchema> = {
+  const selectStmt = {
     where: {
       _projectId,
       isArchived: false,

--- a/test/net/net.ts
+++ b/test/net/net.ts
@@ -514,6 +514,84 @@ describe('Net test', () => {
       expect(fn).to.throw('table: __NOT_EXIST__ is not defined')
     })
 
+    it('should allow query.fields to specify field names to be selected', function* () {
+      httpBackend.whenGET(`${apiHost}/${path}`)
+        .respond(normalEvent)
+      yield net.lift({
+        cacheValidate: CacheStrategy.Cache,
+        request: sdkFetch.get(path),
+        query: {
+          where: { _id: normalEvent._id },
+          fields: ['_id']
+        },
+        tableName: 'Event'
+      } as ApiResult<EventSchema, CacheStrategy.Cache>)
+        .values()
+        .do(([r]) => {
+          expect(r).to.deep.equal({ _id: normalEvent._id })
+        })
+    })
+
+    it(`should allow query.fields to specify field names to be selected, ignoring 'excludeFields'`, function* () {
+      httpBackend.whenGET(`${apiHost}/${path}`)
+        .respond(normalEvent)
+      yield net.lift({
+        cacheValidate: CacheStrategy.Cache,
+        request: sdkFetch.get(path),
+        query: {
+          where: { _id: normalEvent._id },
+          fields: ['_id', 'title']
+        },
+        tableName: 'Event',
+        excludeFields: ['title']
+      } as ApiResult<EventSchema, CacheStrategy.Cache>)
+        .values()
+        .do(([r]) => {
+          expect(r).to.deep.equal({
+            _id: normalEvent._id,
+            title: normalEvent.title
+          })
+        })
+    })
+
+    it(`should allow query.fields to specify field names to be selected, ignoring non-existing ones`, function* () {
+      httpBackend.whenGET(`${apiHost}/${path}`)
+        .respond(normalEvent)
+      yield net.lift({
+        cacheValidate: CacheStrategy.Cache,
+        request: sdkFetch.get(path),
+        query: {
+          where: { _id: normalEvent._id },
+          fields: ['_id', 'noSuchFieldname']
+        },
+        tableName: 'Event'
+      } as ApiResult<EventSchema, CacheStrategy.Cache>)
+        .values()
+        .do(([r]) => {
+          expect(r).to.deep.equal({
+            _id: normalEvent._id
+          })
+        })
+    })
+
+    it(`should ignore empty query.fields, i.e. []`, function* () {
+      httpBackend.whenGET(`${apiHost}/${path}`)
+        .respond(normalEvent)
+      yield net.lift({
+        cacheValidate: CacheStrategy.Cache,
+        request: sdkFetch.get(path),
+        query: {
+          where: { _id: normalEvent._id },
+          fields: []
+        },
+        tableName: 'Event'
+      } as ApiResult<EventSchema, CacheStrategy.Cache>)
+        .values()
+        .do(([r]) => {
+          expectToDeepEqualForFieldsOfTheExpected(r, normalEvent, 'creator')
+        })
+    })
+
   })
 
 })


### PR DESCRIPTION
为接口用户提供正向指定所需查询字段的办法。解除原先用户只能通过 ApiResult.excludeFields 来排除不要查询的字段（逆向指定）的限制。

ApiResult.query.fields 将比 excludeFields 拥有更高优先级，凡是在 ApiResult.query.fields 里指定的可用查询字段，都会出现在查询结果中。（一般情况下，fields 和 excludeFields 不会同时指定；如果是自动化生成的查询，或者是从查询模板生成的查询，才会发生。另：一个边界情况是， ApiResult.query.fields 如果不包含任何元素，即为 []，与没有指定 ApiResult.query.fields 的行为一致，即认为用户没有正向指定查询字段。）