### PR TITLE
fix(schemas): 完善 TasklistSchema 的字段，并整理字段在代码中的排序

### DIFF
--- a/src/schemas/Project.ts
+++ b/src/schemas/Project.ts
@@ -1,5 +1,5 @@
 import { RDBType, SchemaDef, Relationship } from 'reactivedb/interface'
-import { CustomFieldValue, ExecutorOrCreator } from 'teambition-types'
+import { CustomFieldValue, ExecutorOrCreator, TaskSortMethod } from 'teambition-types'
 import { ProjectId, UserId, OrganizationId, RoleId, CollectionId, ApplicationId } from 'teambition-types'
 import { schemaColl } from './schemas'
 import { OrganizationPaymentPlan } from './Organization'
@@ -53,7 +53,7 @@ export interface ProjectSchema {
   pushStatus: boolean
   py: string
   shortLink?: string
-  sortMethod: 'duedate' | 'priority' | 'created_asc' | 'created_desc' | 'startdate' | 'custom'
+  sortMethod: TaskSortMethod
   starsCount: number
   syncCountsAt: string //  a Date
   tagsCount: number

--- a/src/schemas/Tasklist.ts
+++ b/src/schemas/Tasklist.ts
@@ -1,24 +1,27 @@
 import { SchemaDef, RDBType, Relationship } from 'reactivedb/interface'
 import { schemaColl } from './schemas'
 import { StageSchema } from '../schemas/Stage'
-import { TasklistId, StageId, ProjectId, UserId } from 'teambition-types'
+import { TasklistId, TaskSortMethod, ScenarioFieldConfigId, StageId, ProjectId, UserId } from 'teambition-types'
 
 export interface TasklistSchema {
   _id: TasklistId
-  title: string
-  _projectId: ProjectId
   _creatorId: UserId
-  description: string
-  isArchived: boolean
+  _defaultScenariofieldconfigId: ScenarioFieldConfigId | null
+  _projectId: ProjectId
   created: string
-  updated: string
-  stageIds: StageId[]
+  description: string
   doneCount: number
-  undoneCount: number
   expiredCount: number
-  recentCount: number
-  totalCount: number
+  isArchived: boolean
   hasStages: StageSchema[]
+  pos: number
+  recentCount: number
+  sortMethod: TaskSortMethod | ''
+  stageIds: StageId[]
+  title: string
+  totalCount: number
+  undoneCount: number
+  updated: string
 }
 
 const schema: SchemaDef<TasklistSchema> = {
@@ -28,6 +31,9 @@ const schema: SchemaDef<TasklistSchema> = {
   _id: {
     type: RDBType.STRING,
     primaryKey: true
+  },
+  _defaultScenariofieldconfigId: {
+    type: RDBType.STRING
   },
   _projectId: {
     type: RDBType.STRING
@@ -56,8 +62,14 @@ const schema: SchemaDef<TasklistSchema> = {
   isArchived: {
     type: RDBType.BOOLEAN
   },
+  pos: {
+    type: RDBType.NUMBER
+  },
   recentCount: {
     type: RDBType.NUMBER
+  },
+  sortMethod: {
+    type: RDBType.STRING
   },
   stageIds: {
     type: RDBType.LITERAL_ARRAY

--- a/src/teambition.ts
+++ b/src/teambition.ts
@@ -78,6 +78,7 @@ declare module 'teambition-types' {
   export type ScenarioProTemplateConfigType = 'story' | 'bug' | 'subtask'
   export type SmartGroupType = 'story' | 'sprint' | 'bug'
   export type SmartGroupViewType = 'table' | 'time' | 'kanban'
+  export type TaskSortMethod = 'duedate' | 'priority' | 'created_asc' | 'created_desc' | 'startdate' | 'startdate_desc' | 'custom'
   export type SwimAxisLane = 'sprint' | 'subtask' | 'executor' | 'stage' | 'priority' | 'isDone'
     | 'taskType' | 'rating' | 'storyPoint'
   export type TagType = 'organization' | 'project'


### PR DESCRIPTION
...另外，将 sortMethod 对应的类型提出，作 TaskSortMethod，方便单独使用
（用户项目里已经有使用案例）。

TasklistSchema 的 sortMethod 添加了 `''` 类型，与实际后端接口返回匹配。

/cc @coldfannn 