### PR TITLE
perf(EventGenerator): 更高效地找到给定区间在重复规则上的开始点

### DIFF
--- a/src/apis/event/EventGenerator.ts
+++ b/src/apis/event/EventGenerator.ts
@@ -15,6 +15,13 @@ export interface DateInfo {
 
 export type InstanceCreator<T> = (source: T, timeframe?: Timeframe) => T
 
+type CmpOption = 'byStartDate' | 'byEndDate'
+
+type TimeframeFrom = {
+  startDateFrom: Date
+  include: boolean
+}
+
 export class RecurrenceFactory<T extends DateInfo> implements IterableIterator<T | undefined> {
   readonly type: string
 
@@ -76,7 +83,7 @@ export class RecurrenceFactory<T extends DateInfo> implements IterableIterator<T
       return doneRet
     }
 
-    const eventSpan = this.getOneTimeframeFromRecurrence(this.startDateCursor)
+    const eventSpan = this.getOneTimeframeAfter(this.startDateCursor, true)
     if (!eventSpan) {
       this.done = true
       return doneRet
@@ -90,10 +97,7 @@ export class RecurrenceFactory<T extends DateInfo> implements IterableIterator<T
     return result
   }
 
-  private getOneTimeframeFromRecurrence(
-    unadjustedStartDate: Date,
-    include: boolean = true
-  ): Timeframe | null {
+  private getOneTimeframeAfter(unadjustedStartDate: Date, include?: boolean): Timeframe | null {
     // unadjustedStartDate 可能未经 this.rrule.after 过滤，有可能是
     // 一个 exdate（被 rruleset 剔除的日期），发现时需要跳过。
     const startDate = this.rruleSet.after(unadjustedStartDate, include)
@@ -103,15 +107,29 @@ export class RecurrenceFactory<T extends DateInfo> implements IterableIterator<T
       : null
   }
 
+  private takePred = (from: Date, fromCmpOption: CmpOption) =>
+    (eSpan?: Timeframe): boolean | TimeframeFrom => {
+      switch (fromCmpOption) {
+        case 'byStartDate':
+          // 用开始时间来判断一个实例是否应该出现在当前区间的话，它可以晚于或等于 from
+          return eSpan ? eSpan.startDate >= from : {
+            startDateFrom: from,
+            include: true
+          }
+        case 'byEndDate':
+          // 用结束时间来判断一个实例是否应该出现在当前区间的话，它必须要严格晚于 from
+          return eSpan ? eSpan.endDate > from : {
+            startDateFrom: new Date(from.valueOf() - this.duration),
+            include: false
+          }
+      }
+    }
+
   private slice(
-    from: Date, fromCmpOption: 'byStartDate' | 'byEndDate',
-    to: Date, toCmpOption: 'byStartDate' | 'byEndDate'
+    from: Date, fromCmpOption: CmpOption,
+    to: Date, toCmpOption: CmpOption
   ): Timeframe[] {
-    const skipPred = (eSpan: Timeframe): boolean =>
-      // 用开始时间来判断一个实例是否应该出现在当前区间的话，它可以晚于或等于 from
-      fromCmpOption === 'byStartDate' && eSpan.startDate < from
-    // 用结束时间来判断一个实例是否应该出现在当前区间的话，它必须要严格晚于 from
-      || fromCmpOption === 'byEndDate' && eSpan.endDate <= from
+    const takePred = this.takePred(from, fromCmpOption)
 
     const stopPred = (eSpan: Timeframe): boolean => {
       // 用开始时间来判断一个实例是否应该出现在当前区间的话，它必须严格早于 to
@@ -128,7 +146,7 @@ export class RecurrenceFactory<T extends DateInfo> implements IterableIterator<T
         startDate: new Date(this.source.startDate),
         endDate: new Date(this.source.endDate)
       }
-      if (!skipPred(initialEventSpan) && !stopPred(initialEventSpan)) {
+      if (takePred(initialEventSpan) as boolean && !stopPred(initialEventSpan)) {
         // eventSpan 在时间范围内
         result.push(initialEventSpan)
       }
@@ -136,7 +154,9 @@ export class RecurrenceFactory<T extends DateInfo> implements IterableIterator<T
     }
     // this.isRecurrence is truthy
 
-    initialEventSpan = this.getOneTimeframeFromRecurrence(new Date(this.source.startDate))
+    const initial = takePred() as TimeframeFrom
+    initialEventSpan = this.getOneTimeframeAfter(initial.startDateFrom, initial.include)
+
     if (!initialEventSpan) {
       return []
     }
@@ -145,15 +165,12 @@ export class RecurrenceFactory<T extends DateInfo> implements IterableIterator<T
     for (
       curr = initialEventSpan;
       curr !== null;
-      curr = this.getOneTimeframeFromRecurrence(curr.startDate, false)
+      curr = this.getOneTimeframeAfter(curr.startDate)
     ) {
-      if (stopPred(curr)) { // 优先检查停止条件
+      // note: 任何一个 time frame 都需要通过 stopPred 才可以用，initialEventSpan 也不例外
+      if (stopPred(curr)) {
         break
       }
-      if (skipPred(curr)) { // 其次检查忽略条件
-        continue
-      }
-
       result.push(curr)
     }
 
@@ -194,7 +211,7 @@ export class RecurrenceFactory<T extends DateInfo> implements IterableIterator<T
       }
     }
     // this.isRecurrence is truthy
-    const targetEventSpan = this.getOneTimeframeFromRecurrence(date)
+    const targetEventSpan = this.getOneTimeframeAfter(date, true)
     if (!targetEventSpan) {
       return null
     } else {
@@ -209,7 +226,7 @@ export class RecurrenceFactory<T extends DateInfo> implements IterableIterator<T
     }
     // expectedDate is a valid Date object
 
-    const targetEventSpan = this.getOneTimeframeFromRecurrence(expectedDate)
+    const targetEventSpan = this.getOneTimeframeAfter(expectedDate, true)
     if (!targetEventSpan || targetEventSpan.startDate.valueOf() !== expectedDate.valueOf()) {
       return null
     }


### PR DESCRIPTION
先前的实现，需要从重复规则最早的时间点开始，一个个检查（skip）直到找到
第一个符合区间条件的 timeframe，并将随后的每个 timeframe 生成出来，直
到遇到第一个不符合区间条件的 timeframe 停止。

如果一个重复规则有很多很多出现在区间条件之前的 timeframe，那么开始的
skip 操作就会很多。事实证明，skip 操作里包含的对 RRuleSet after() 的调
用是很昂贵的。

新的实现，去掉了一个个 skip 掉区间条件之前 timeframe 的过程，直接找到
第一个符合区间条件的日程，节省计算昂贵的 RRuleSet after() 调用。