### PR TITLE
fix(deps): 避免由 `JoinMode` 引入整个 reactivedb 依赖

### DIFF
--- a/src/Net/Net.ts
+++ b/src/Net/Net.ts
@@ -9,13 +9,8 @@ import 'rxjs/add/operator/filter'
 import { Observable } from 'rxjs/Observable'
 import { BehaviorSubject } from 'rxjs/BehaviorSubject'
 import { QueryToken, SelectorMeta, ProxySelector } from 'reactivedb/proxy'
-import {
-  Database,
-  Query,
-  Predicate,
-  ExecutorResult,
-  JoinMode
- } from 'reactivedb'
+import { JoinMode } from 'reactivedb/interface'
+import { Database, Query, Predicate, ExecutorResult } from 'reactivedb'
 
 import { forEach, ParsedWSMsg, WSMsgToDBHandler, GeneralSchemaDef } from '../utils'
 import { SDKLogger } from '../utils/Logger'


### PR DESCRIPTION
JoinMode 虽然是一个 interface，但由于其本身是一个 enum，TS 在转译的时候会产生运行时代码。 所以这里从 根入口去引用 这个属性会导致整个 reactivedb 的依赖一同进入到项目中，而这在某些场景中是不应该发生的。