### PR TITLE
fix: 移除不再使用的 `isInbox` 字段

### DIFF
--- a/src/schemas/Favorite.ts
+++ b/src/schemas/Favorite.ts
@@ -21,7 +21,6 @@ export interface FavoriteData extends ISchema {
   created: string
   updated: string
   refType: DetailObjectType
-  isInbox?: boolean
   isVisible: boolean
   isUpdated: boolean
   status: 'deleted' | 'invisible' | 'archived' | 'updated' | ''

--- a/src/schemas/Subtask.ts
+++ b/src/schemas/Subtask.ts
@@ -21,7 +21,6 @@ export interface SubtaskData extends ISchema {
   order: number
   executor: ExecutorOrCreator
   updated?: string
-  isInbox?: boolean
 }
 
 @schemaName('Subtask')


### PR DESCRIPTION
该字段曾被用于标识自由任务