### PR TITLE
fix(SDKFetch): 避免在 query 唯一键对应值为 [] 时得错误 url

### DIFF
--- a/mock/mock.ts
+++ b/mock/mock.ts
@@ -11,50 +11,48 @@ export interface FetchResult {
 export const fetchStack: Map<string, FetchResult[]> = new Map<string, any>()
 
 export const buildQuery = (url: string, query: any) => {
-  if (typeof query !== 'object' || !query) {
+  return appendQueryString(url, toQueryString(query))
+}
+
+const appendQueryString = (url: string, queryString: string) => {
+  if (!queryString) {
     return url
   }
+  if (url.slice(-1) === '?') { // '?' 是最后一个字符
+    return `${url}${queryString}`
+  }
+  return url.indexOf('?') === -1
+    ? `${url}?${queryString}`  // '?' 不存在
+    : `${url}&${queryString}`  // '?' 存在，其后还有其他字符
+}
+
+const toQueryString = (query: any) => {
+  if (typeof query !== 'object' || !query) {
+    return ''
+  }
   const result: string[] = []
-  const pushKVToResult = pushKVEncoded(result)
   Object.keys(query).forEach((key) => {
     const val = query[key]
     if (key === '_') {
       console.warn('query should not contain key \'_\', it will be ignored')
-      return
+    } else if (Array.isArray(val)) {
+      val.forEach(_val => {
+        result.push(`${key}=${encoded(_val)}`)
+      })
+    } else if (typeof val !== 'undefined') {
+      result.push(`${key}=${encoded(val)}`)
     }
-    if (Array.isArray(val)) {
-      val.forEach(_val => pushKVToResult(key, _val))
-      return
-    }
-    pushKVToResult(key, val)
   })
-  let _query: string
-  if (url.indexOf('?') !== -1) {
-    const hasExistingQueryInUrl = url.slice(-1) !== '?'
-    const additionalQuery = result.join('&')
-    _query = hasExistingQueryInUrl && additionalQuery
-      ? '&' + additionalQuery
-      : additionalQuery
-  } else {
-    _query = result.length ? '?' + result.join('&') : ''
-  }
-  return url + _query
+  return result.join('&')
 }
 
-const pushKVEncoded = (array: string[]) => (key: string, value: any): void => {
-  if (typeof value === 'undefined') {
-    return
-  }
-
+const encoded = (value: {} | null): string => {
   const encodedRegExp = /^(%(\d|[a-fA-F]){2}|[a-zA-Z0-9]|-|_|\.|!|~|\*|'|\(|\))*$/
   //                       ^percent-encoded^ ^^^^^^^^^^^^^escaped^^^^^^^^^^^^^w
-
   const maybeEncoded = String(value)
-  const encoded = encodedRegExp.test(maybeEncoded)
+  return encodedRegExp.test(maybeEncoded)
     ? maybeEncoded
     : encodeURIComponent(maybeEncoded)
-
-  array.push(`${key}=${encoded}`)
 }
 
 export function parseObject (query: any): string {

--- a/src/SDKFetch.ts
+++ b/src/SDKFetch.ts
@@ -7,7 +7,7 @@ import 'rxjs/add/operator/finally'
 import { Observable } from 'rxjs/Observable'
 import { Http, HttpErrorMessage, HttpResponseWithHeaders, getHttpWithResponseHeaders } from './Net/Http'
 import { UserMe } from './schemas/UserMe'
-import { forEach, isEmptyObject, uuid } from './utils'
+import { forEach, uuid } from './utils'
 import { SDKLogger } from './utils/Logger'
 
 export type SDKFetchOptions = {
@@ -117,7 +117,7 @@ export class SDKFetch {
 
     if (!SDKFetch.FetchStack.has(urlWithQuery)) {
       const tail = SDKFetch.fetchTail || Date.now()
-      const urlWithTail = query && !isEmptyObject(query)
+      const urlWithTail = urlWithQuery.indexOf('?') !== -1
         ? `${ urlWithQuery }&_=${ tail }`
         : `${ urlWithQuery }?_=${ tail }`
       dist = Observable.defer(() => http.setUrl(urlWithTail).get().send() as any)


### PR DESCRIPTION
纠正在如 `{ involveMembers: [] }` 的 query 对象下，生成的 url 在时间戳片段（`_=nnnnnnnn`）之前带有 `&` 的错误。

问题出现的原因，从代码组织的角度看，是在生成 urlWithTail 时使用的判断条件之一 isEmptyObject(query) 与 buildQuery 内部更准确的空条件判断不吻合，遗漏了空数组的检查。所以，用判断由 buildQuery 生成的 urlWithQuery 是否含有查询部分，来代替原来的 `query && !isEmptyObject(query)`，保证始终使用 buildQuery 的内部判断逻辑，避免以后出现类似问题。

...resolves #535