### PR TITLE
feat(schemas/Task): 补充已在使用中的 `creator` 字段

### DIFF
--- a/src/schemas/Task.ts
+++ b/src/schemas/Task.ts
@@ -32,6 +32,7 @@ export interface TaskSchema {
   isArchived: boolean
   isDeleted: boolean
   created: string
+  creator?: ExecutorOrCreator
   updated: string
   visible: VisibleOption
   _organizationId: OrganizationId | null
@@ -144,6 +145,15 @@ const schema: SchemaDef<TaskSchema> = {
   },
   created: {
     type: RDBType.DATE_TIME
+  },
+  creator: {
+    type: Relationship.oneToOne,
+    virtual: {
+      name: 'User',
+      where: (userTable: any) => ({
+        _creatorId: userTable._id
+      })
+    }
   },
   customfields: {
     type: RDBType.OBJECT

--- a/test/apis/task.spec.ts
+++ b/test/apis/task.spec.ts
@@ -51,6 +51,7 @@ describe('TaskApi socket spec', () => {
     yield sdk.database.get<TaskSchema>('Task', { where: { _id: fixture._id } })
       .values()
       .do(([r]) => {
+        delete r.creator
         delete r.project
         looseDeepEqual(r, fixture)
       })


### PR DESCRIPTION
@chuan6 我在等待后端答复（任务接口都是有返回 `creator` 字段？）。