### PR TITLE
fix(graphql): 补充简单的 errors 字段处理机制

### DIFF
--- a/src/SDK.ts
+++ b/src/SDK.ts
@@ -60,6 +60,10 @@ export class SDK {
     }
   }
 
+  graph<T extends object>(query: string, variables: Variables, withHeaders: true): Observable<T & { headers: Headers }>
+  graph<T extends object>(query: string, variables: Variables, withHeaders: false): Observable<T>
+  graph<T extends object>(query: string, variables?: Variables): Observable<T>
+  graph<T extends object>(query: string): Observable<T>
   graph<T extends object>(query: string, variables?: Variables, withHeaders: boolean = false) {
     if (this.graphQLClientOption == null) {
       throw Error('GraphQL server should be specified.')
@@ -77,11 +81,12 @@ export class SDK {
         { ...this.graphQLClientOption, includeHeaders: true }
       )
       .map(({ headers, body }) => {
-        if (withHeaders) {
-          const data: object = body.data
-          return  ({ ...data, headers: headers })
+        const { errors, data } = body
+        if (errors) {
+          const errmsg = errors.map(({ message }) => `${message}`)
+          throw new Error(errmsg.join('\n'))
         }
-        return body.data
+        return withHeaders ? { ...(data! as any), headers } : data!
       })
   }
 

--- a/src/utils/internalTypes.ts
+++ b/src/utils/internalTypes.ts
@@ -64,9 +64,18 @@ export interface GraphQLRequestContext {
   variables?: Variables
 }
 
-export interface GraphQLResponse<T = any> {
-  data: T
-  errors?: Error[]
+// see: http://facebook.github.io/graphql/June2018/#sec-Errors
+export type GraphQLError = {
+  message: string
+  path?: Array<string | number>
+  locations?: Array<{ line: number, column: number }>
+  extensions?: { [key: string ]: any }
+}
+
+// see: http://facebook.github.io/graphql/June2018/#sec-Response-Format
+export interface GraphQLResponse<T = { [key: string]: any }> {
+  data?: T | null // see: http://facebook.github.io/graphql/June2018/#sec-Data
+  errors?: GraphQLError[] // see: http://facebook.github.io/graphql/June2018/#sec-Errors
   extensions?: any
   status: number
   [key: string]: any


### PR DESCRIPTION
- [x] 在对应项目中试跑，确认没破坏当前基本行为。

这里的实现，粗暴地在后端提供了 `errors` 字段后就放弃 `data` 字段可能存在的有用数据。接下来，应该支持通过解析 `errors` 里 `path` 字段的信息，来支持 `data` 字段数据的部分可用性。https://github.com/teambition/teambition-sdk/issues/552