### PR TITLE
fix(net/validate): 避免 switchMap 中断 padding 请求导致的循环请求

### DIFF
--- a/src/Net/Net.ts
+++ b/src/Net/Net.ts
@@ -2,6 +2,7 @@ import 'rxjs/add/observable/forkJoin'
 import 'rxjs/add/observable/of'
 import 'rxjs/add/operator/concatAll'
 import 'rxjs/add/operator/do'
+import 'rxjs/add/operator/exhaustMap'
 import 'rxjs/add/operator/mapTo'
 import 'rxjs/add/operator/mergeMap'
 import 'rxjs/add/operator/switchMap'
@@ -155,15 +156,17 @@ export class Net {
     const hasPaddingFunction = typeof padding === 'function'
     const pk = this.primaryKeys.get(tableName)
 
-    const fn = (stream$: Observable<T[]>) =>
-      stream$.switchMap(data => !data.length
-        ? Observable.of(data)
-        : Observable.forkJoin(
-          Observable.from(data)
+    let fn: (stream$: Observable<T[]>) => Observable<T[]>
+
+    if (!hasRequiredFields || !hasPaddingFunction || !pk) {
+      fn = (stream$) => stream$ // pass through
+    } else {
+      fn = (stream$) =>
+        stream$.exhaustMap(data => !data.length
+          ? Observable.of(data)
+          : Observable.from(data)
             .mergeMap(datum => {
-              if (!hasRequiredFields || !hasPaddingFunction || !pk ||
-                required!.every(k => typeof datum[k] !== 'undefined')
-              ) {
+              if (required!.every(k => typeof datum[k] !== 'undefined')) {
                 return Observable.of(datum)
               }
               const patch = padding!(datum[pk]).filter(r => r != null) as Observable<T>
@@ -171,9 +174,9 @@ export class Net {
                 .concatMap(r => this.database!.upsert(tableName, r).mapTo(r))
                 .do(r => Object.assign(datum, r))
             })
+            .mapTo(data)
         )
-          .mapTo(data)
-      )
+    }
     fn.toString = () => 'SDK_VALIDATE'
     return fn
   }


### PR DESCRIPTION
当 query token 推出一组 data 时，里面如果存在多个条目需要 padding，那
么就会发出多个请求。当其中有一个请求返回，其结果被 upsert 到 db，就导
致 query token 生成的数据流的新一次推送，造成正在进行的其他 padding 请
求被切掉。而新推出的 data 依然有条目需要 padding，就又要重新开始一系列
padding 请求。依此往复。

exhaustMap 的使用，避免了当前一次推送对应的一系列 padding 请求被切掉。
在 padding 期间的更多推送都被忽略。当 padding 完成，由其更新过的 data
会被推出来，作为最新数据。

另外：令不需要 validate 步骤的数据流直接 pass through，成本低一些。