### PR TITLE
feat(pagination): 支持 page + count 类型分页请求

### DIFF
--- a/src/Net/Pagination.ts
+++ b/src/Net/Pagination.ts
@@ -2,54 +2,97 @@ import 'rxjs/add/observable/throw'
 import 'rxjs/add/operator/startWith'
 import 'rxjs/add/operator/withLatestFrom'
 import { Observable } from 'rxjs/Observable'
-import { Observer } from 'rxjs/Observer'
 import { OperatorFunction } from 'rxjs/interfaces'
+import { Omit } from '../utils'
 
 export type PageToken = string & { kind: 'PageToken' }
 
 export const emptyPageToken = '' as PageToken
 
-export interface State<T = {}> {
+export enum Kind {
+  PageCount = 'PageCount',
+  PageToken = 'PageToken'
+}
+
+export type CommonState<T = {}> = {
+  kind: Kind
+
   urlPath: string
 
-  pageSize?: number
+  pageSize: number
   urlQuery?: {}
 
-  nextPageToken: PageToken
-  totalSize?: number
   result: T[]
 
   nextPage: number
   hasMore: boolean
+  limit: number
 }
 
+export type PageCountState<T = {}> = CommonState<T> & {
+  kind: Kind.PageCount
+}
+
+export type PageTokenState<T = {}> = CommonState<T> & {
+  kind: Kind.PageToken
+  nextPageToken: PageToken
+  totalSize?: number
+}
+
+export type State<T = {}> = PageTokenState<T>
+
+export type PolyState<T = {}> = PageCountState<T> | PageTokenState<T>
+
+export type StateOptions = {
+  kind?: Kind
+  pageSize?: number
+  urlQuery?: {}
+}
+
+export type InitOptions<T extends {} = {}> = Omit<StateOptions, 'kind'> & {
+  urlQuery?: T
+}
+
+export type Update<T> = {
+  patch?: T[]
+  limit?: number
+}
+
+export function defaultState<T>(urlPath: string, options: StateOptions & { kind: Kind.PageCount }): PageCountState<T>
+export function defaultState<T>(urlPath: string): PageTokenState<T>
+export function defaultState<T>(urlPath: string, options: Omit<StateOptions, 'kind'>): PageTokenState<T>
+export function defaultState<T>(urlPath: string, options: StateOptions & { kind: Kind.PageToken }): PageTokenState<T>
+export function defaultState<T>(urlPath: string, options: StateOptions): PolyState<T>
 export function defaultState<T>(
   urlPath: string,
-  options: {
-    pageSize?: number
-    urlQuery?: {}
-  } = {}
-): State<T> {
-  const raw: State<T> = {
-    urlPath: urlPath,
-    nextPageToken: emptyPageToken,
-    totalSize: undefined,
+  options: StateOptions = {}
+): PolyState<T> {
+  const state: CommonState<T> = {
+    kind: options.kind || Kind.PageToken,
+    urlPath,
     result: [],
-
     nextPage: 1,
-    hasMore: true
+    hasMore: true,
+    urlQuery: undefined,
+    pageSize: 50,
+    limit: 0
   }
-  if (options.pageSize) {
-    Object.assign(raw, { pageSize: options.pageSize })
-  }
+
   if (options.urlQuery) {
-    const { pageSize, ...nonPaginationQuery } = options.urlQuery as any
-    Object.assign(raw, { urlQuery: nonPaginationQuery })
-    if (!raw.pageSize && pageSize) {
-      raw.pageSize = pageSize
-    }
+    const { pageSize: queryPageSize, ...nonPaginationQuery } = options.urlQuery as any
+    state.urlQuery = nonPaginationQuery
+    state.pageSize = queryPageSize || state.pageSize
   }
-  return raw
+  state.pageSize = options.pageSize || state.pageSize
+
+  return state.kind === Kind.PageCount
+    ? state as PageCountState<T>
+    : { ...state, nextPageToken: emptyPageToken, totalSize: undefined } as PageTokenState<T>
+}
+
+// todo: test, doc
+export function queryInfo<T>(state: CommonState<T>): Update<T> {
+  return { patch: state.result, limit: state.limit }
 }
 
 export type OriginalResponse<T> = {
@@ -58,65 +101,104 @@ export type OriginalResponse<T> = {
   totalSize?: number
 }
 
-export const accumulateResultByConcat = <T>(state: State<T>, resp: OriginalResponse<T>): State<T> => {
-  return {
-    ...state,
-    totalSize: resp.totalSize,
-    nextPageToken: resp.nextPageToken,
-    result: state.result.concat(resp.result),
-    nextPage: state.nextPage + 1,
-    hasMore: Boolean(resp.nextPageToken) && resp.result.length === state.pageSize
+export function accWithoutConcat<T>(state: PageCountState<T>, resp: T[]): PageCountState<T>
+export function accWithoutConcat<T>(state: PageTokenState<T>, resp: OriginalResponse<T>): PageTokenState<T>
+export function accWithoutConcat<T>(state: PolyState<T>, resp: OriginalResponse<T> | T[]): PolyState<T>
+export function accWithoutConcat<T>(
+  state: PolyState<T>,
+  resp: OriginalResponse<T> | T[]
+): PolyState<T> {
+  const nextPage = state.nextPage + 1
+  const limit = state.nextPage * state.pageSize
+
+  switch (state.kind) {
+    case Kind.PageCount: {
+      const r = resp as T[]
+      const hasMore = r.length === state.pageSize
+      const result = r
+      return { ...state, nextPage, limit, hasMore, result }
+    }
+    case Kind.PageToken: {
+      const r = resp as OriginalResponse<T>
+      const hasMore = Boolean(r.nextPageToken) && r.result.length === state.pageSize
+      const result = r.result
+      const nextPageToken = r.nextPageToken
+      const totalSize = r.totalSize
+      return { ...state, nextPage, limit, hasMore, result, nextPageToken, totalSize }
+    }
+    default:
+      return state // 没有对应的操作，将 state 原样返回
   }
 }
 
-export const loadAndExpand = <T>(
-  step: (curr: State<T>) => Observable<OriginalResponse<T>>,
-  initState: State<T>,
-  loadMore$: Observable<{}> = Observable.empty()
-): Observable<State<T>> => {
-  return loadMore$.startWith({})
-    .pipe(expand(step, accumulateResultByConcat, initState))
-    .mergeAll()
+export function acc<T>(state: PageCountState<T>, resp: T[]): PageCountState<T>
+export function acc<T>(state: PageTokenState<T>, resp: OriginalResponse<T>): PageTokenState<T>
+export function acc<T>(state: PolyState<T>, resp: OriginalResponse<T> | T[]): PolyState<T>
+export function acc<T>(state: PolyState<T>, resp: OriginalResponse<T> | T[]): PolyState<T> {
+  const nextState = accWithoutConcat(state, resp)
+  if (nextState === state) {
+    return nextState // 没有对应的操作，将 state 原样返回
+  }
+  nextState.result = state.result.concat(nextState.result)
+  return nextState
 }
 
-export const expand = <T>(
-  step: (curr: State<T>) => Observable<OriginalResponse<T>>,
-  accumulator: (state: State<T>, resp: OriginalResponse<T>) => State<T>,
-  initState: State<T>
-): OperatorFunction<{}, Observable<State<T>>> => (
-  source$
-) => {
-  const state = { ...initState }
-  let isLoading = false
+export function expand<T>(
+  step: (curr: PageCountState<T>) => Observable<T[]>,
+  accumulate: (state: PageCountState<T>, resp: T[]) => PageCountState<T>,
+  initState: PageCountState<T>
+): OperatorFunction<{}, Observable<PageCountState<T>>>
 
-  return Observable.create((observer: Observer<Observable<State<T>>>) => {
-    const subs = source$.subscribe({
-      next: (_) => {
-        if (!state.hasMore) {
+export function expand<T>(
+  step: (curr: PageTokenState<T>) => Observable<OriginalResponse<T>>,
+  accumulate: (state: PageTokenState<T>, resp: OriginalResponse<T>) => PageTokenState<T>,
+  initState: PageTokenState<T>
+): OperatorFunction<{}, Observable<PageTokenState<T>>>
+
+export function expand<T>(
+  step: ((curr: PolyState<T>) => Observable<unknown>),
+  accumulator: (state: PolyState<T>, resp: any) => PolyState<T>,
+  initState: PolyState<T>
+): OperatorFunction<{}, Observable<PolyState<T>>>
+
+export function expand<T>(
+  step: ((curr: any) => Observable<any>),
+  accumulator: (state: any, resp: any) => PolyState<T>,
+  initState: PolyState<T>
+): OperatorFunction<{}, Observable<PolyState<T>>> {
+  return (source$) => {
+    const state = { ...initState }
+    let isLoading = false
+
+    return new Observable((observer) => {
+      const subs = source$.subscribe({
+        next: (_) => {
+          if (!state.hasMore) {
+            observer.complete()
+            return
+          }
+          if (!isLoading) {
+            isLoading = true
+            observer.next(step(state)
+              .map((stepResult) => accumulator(state, stepResult))
+              .do((expanded) => Object.assign(state, expanded))
+              .catch((err) => Observable.throw(err))
+              .finally(() => { isLoading = false })
+            )
+          }
+        },
+        error: (err) => {
+          isLoading = false
+          observer.error(err)
+        },
+        complete: () => {
           observer.complete()
-          return
         }
-        if (!isLoading) {
-          isLoading = true
-          observer.next(step(state)
-            .map((stepResult) => accumulator(state, stepResult))
-            .do((expanded) => Object.assign(state, expanded))
-            .catch((err) => Observable.throw(err))
-            .finally(() => { isLoading = false })
-          )
-        }
-      },
-      error: (err) => {
-        isLoading = false
-        observer.error(err)
-      },
-      complete: () => {
-        observer.complete()
+      })
+
+      return () => {
+        subs.unsubscribe()
       }
     })
-
-    return () => {
-      subs.unsubscribe()
-    }
-  }) as Observable<Observable<State<T>>>
+  }
 }

--- a/src/Net/Pagination.ts
+++ b/src/Net/Pagination.ts
@@ -101,10 +101,10 @@ export type OriginalResponse<T> = {
   totalSize?: number
 }
 
-export function accWithoutConcat<T>(state: PageCountState<T>, resp: T[]): PageCountState<T>
-export function accWithoutConcat<T>(state: PageTokenState<T>, resp: OriginalResponse<T>): PageTokenState<T>
-export function accWithoutConcat<T>(state: PolyState<T>, resp: OriginalResponse<T> | T[]): PolyState<T>
-export function accWithoutConcat<T>(
+export function accUpdate<T>(state: PageCountState<T>, resp: T[]): PageCountState<T>
+export function accUpdate<T>(state: PageTokenState<T>, resp: OriginalResponse<T>): PageTokenState<T>
+export function accUpdate<T>(state: PolyState<T>, resp: OriginalResponse<T> | T[]): PolyState<T>
+export function accUpdate<T>(
   state: PolyState<T>,
   resp: OriginalResponse<T> | T[]
 ): PolyState<T> {
@@ -131,11 +131,11 @@ export function accWithoutConcat<T>(
   }
 }
 
-export function acc<T>(state: PageCountState<T>, resp: T[]): PageCountState<T>
-export function acc<T>(state: PageTokenState<T>, resp: OriginalResponse<T>): PageTokenState<T>
-export function acc<T>(state: PolyState<T>, resp: OriginalResponse<T> | T[]): PolyState<T>
-export function acc<T>(state: PolyState<T>, resp: OriginalResponse<T> | T[]): PolyState<T> {
-  const nextState = accWithoutConcat(state, resp)
+export function accConcat<T>(state: PageCountState<T>, resp: T[]): PageCountState<T>
+export function accConcat<T>(state: PageTokenState<T>, resp: OriginalResponse<T>): PageTokenState<T>
+export function accConcat<T>(state: PolyState<T>, resp: OriginalResponse<T> | T[]): PolyState<T>
+export function accConcat<T>(state: PolyState<T>, resp: OriginalResponse<T> | T[]): PolyState<T> {
+  const nextState = accUpdate(state, resp)
   if (nextState === state) {
     return nextState // 没有对应的操作，将 state 原样返回
   }

--- a/src/apis/pagination.ts
+++ b/src/apis/pagination.ts
@@ -116,7 +116,7 @@ export function expandPage<T, K = T>(
     .startWith({})
     .pipe(Page.expand<K>(
       (s) => this.page(s, requestOptions),
-      skipConcat ? Page.accWithoutConcat : Page.acc,
+      skipConcat ? Page.accUpdate : Page.accConcat,
       state
     ))
     .mergeAll()

--- a/src/utils/internalTypes.ts
+++ b/src/utils/internalTypes.ts
@@ -18,6 +18,8 @@ export type Dict<T> = {
   [key: string]: T
 }
 
+export type Omit<T, U> = Pick<T, Exclude<keyof T, U>>
+
 export type TableInfo = {
   tabName: string,
   pkName: string

--- a/test/net/pagination.ts
+++ b/test/net/pagination.ts
@@ -82,7 +82,7 @@ describe('Pagination Spec', () => {
       const source$ = Observable.empty()
       const expandOp = page.expand(
         () => Observable.of(sampleResponse),
-        page.acc,
+        page.accConcat,
         page.defaultState<number>('')
       )
       let isCompleted = false
@@ -111,7 +111,7 @@ describe('Pagination Spec', () => {
           }
           return Observable.of(sampleResponse)
         },
-        page.acc,
+        page.accConcat,
         page.defaultState<number>('')
       )
       let isCompleted = false
@@ -132,7 +132,7 @@ describe('Pagination Spec', () => {
       const source$ = Observable.throw(sampleError)
       const expandOp = page.expand(
         () => Observable.of(sampleResponse),
-        page.acc,
+        page.accConcat,
         page.defaultState<number>('')
       )
       let isErrorPassedThrough = false
@@ -158,7 +158,7 @@ describe('Pagination Spec', () => {
       })
       const expandOp = page.expand(
         () => Observable.of(sampleResponse),
-        page.acc,
+        page.accConcat,
         page.defaultState<number>('')
       )
       yield source$.pipe(expandOp).mergeAll().do((x) => {
@@ -172,7 +172,7 @@ describe('Pagination Spec', () => {
       const source$ = Observable.interval(10).take(3)
       const expandOp = page.expand(
         () => Observable.of(sampleResponse).delay(25),
-        page.acc,
+        page.accConcat,
         page.defaultState<number>('')
       )
       const page$ = source$.pipe(expandOp).mergeAll().publishReplay(1).refCount()
@@ -211,7 +211,7 @@ describe('Pagination Spec', () => {
           }
           return Observable.of(sampleResponse)
         },
-        page.acc,
+        page.accConcat,
         page.defaultState<number>('')
       )
       yield Observable.from(['first load', 'second load'])
@@ -240,7 +240,7 @@ describe('Pagination Spec', () => {
           }
           return Observable.of(sampleNextResponse)
         },
-        page.acc,
+        page.accConcat,
         {
           ...page.defaultState(''),
           nextPage: 2,

--- a/test/net/pagination.ts
+++ b/test/net/pagination.ts
@@ -6,6 +6,7 @@ import * as page from '../../src/Net/Pagination'
 import { expandPage } from '../../src/apis/pagination'
 
 const fetchMock = require('fetch-mock')
+const querystring = require('querystring')
 
 describe('Pagination Spec', () => {
   const urlPath = 'task'
@@ -15,209 +16,249 @@ describe('Pagination Spec', () => {
     nextPageToken: '456' as page.PageToken
   }
 
-  it(`${page.defaultState.name} should be immutable`, () => {
-    const app1Changes = page.defaultState(urlPath)
-    const app2remains = page.defaultState(urlPath)
-    Object.assign(app1Changes, { paginationUrlPath: 'event' })
-    Object.assign(app1Changes, { additional: 'info' })
-    expect(app2remains).to.deep.equal(page.defaultState(urlPath))
-  })
-
-  it(`${page.defaultState.name} should allow options: pageSize`, () => {
-    expect(page.defaultState(urlPath, { pageSize: 11 }).pageSize).to.equal(11)
-  })
-
-  it(`${page.defaultState.name} should allow options: urlQuery`, () => {
-    expect(page.defaultState(urlPath, { urlQuery: {} }).urlQuery).to.deep.equal({})
-    expect(page.defaultState(urlPath, { urlQuery: { q: 'haha' } }).urlQuery).to.deep.equal({ q: 'haha' })
-  })
-
-  it(`${page.defaultState.name} should allow pageSize be specified in options.urlQuery`, () => {
-    expect(page.defaultState(urlPath, { urlQuery: { pageSize: 11 } }).pageSize).to.equal(11)
-    expect(page.defaultState(urlPath, { pageSize: 11, urlQuery: { pageSize: 22 } }).pageSize).to.equal(11)
-  })
-
-  it(`${page.expand.name} should complete on source$ completion`, function* () {
-    const source$ = Observable.empty()
-    const expandOp = page.expand(
-      () => Observable.of(sampleResponse),
-      page.accumulateResultByConcat,
-      page.defaultState('')
-    )
-    let isCompleted = false
-    yield source$.pipe(expandOp).mergeAll().do({
-      complete: () => {
-        isCompleted = true
-      }
+  describe(`${page.defaultState.name}()`, () => {
+    it(`should be immutable`, () => {
+      const app1Changes = page.defaultState(urlPath)
+      const app2remains = page.defaultState(urlPath)
+      Object.assign(app1Changes, { paginationUrlPath: 'event' })
+      Object.assign(app1Changes, { additional: 'info' })
+      expect(app2remains).to.deep.equal(page.defaultState(urlPath))
     })
-    yield Observable.of(isCompleted)
-      .do((x) => {
-        expect(x).to.be.true
-      })
+
+    it(`should default to kind '${page.Kind.PageToken}'`, () => {
+      expect(page.defaultState(urlPath).kind).to.equal(page.Kind.PageToken)
+    })
+
+    it(`should allow options: kind`, () => {
+      expect(page.defaultState(urlPath, { kind: page.Kind.PageCount }).kind).to.equal(page.Kind.PageCount)
+      expect(page.defaultState(urlPath, { kind: page.Kind.PageToken }).kind).to.equal(page.Kind.PageToken)
+    })
+
+    it(`should allow options: pageSize`, () => {
+      expect(page.defaultState(urlPath, { pageSize: 11 }).pageSize).to.equal(11)
+    })
+
+    it(`should allow options: urlQuery`, () => {
+      expect(page.defaultState(urlPath, { urlQuery: {} }).urlQuery).to.deep.equal({})
+      expect(page.defaultState(urlPath, { urlQuery: { q: 'haha' } }).urlQuery).to.deep.equal({ q: 'haha' })
+    })
+
+    it(`should allow pageSize be specified in options.urlQuery`, () => {
+      expect(page.defaultState(urlPath, { urlQuery: { pageSize: 11 } }).pageSize).to.equal(11)
+      expect(page.defaultState(urlPath, { pageSize: 11, urlQuery: { pageSize: 22 } }).pageSize).to.equal(11)
+    })
+
+    it(`should produce expected state shape for each kind`, () => {
+      const expectedKindAState = {
+        kind: page.Kind.PageCount,
+        urlPath,
+        result: [],
+        nextPage: 1,
+        hasMore: true,
+        urlQuery: undefined,
+        pageSize: 50,
+        limit: 0
+      }
+      const expectedKindBState = {
+        kind: page.Kind.PageToken,
+        urlPath,
+        result: [],
+        nextPage: 1,
+        hasMore: true,
+        urlQuery: undefined,
+        pageSize: 50,
+        limit: 0,
+        nextPageToken: page.emptyPageToken,
+        totalSize: undefined
+      }
+      expect(page.defaultState(urlPath, { kind: page.Kind.PageCount })).to.deep.equal(expectedKindAState)
+      expect(page.defaultState(urlPath)).to.deep.equal(expectedKindBState)
+      expect(page.defaultState(urlPath, { kind: page.Kind.PageToken })).to.deep.equal(expectedKindBState)
+    })
   })
 
-  it(`${page.expand.name} should complete on hasMore: false`, function* () {
-    let hasMore = true
-    const sampleHasNoMoreResponse = {
-      result: [4, 5, 6],
-      nextPageToken: page.emptyPageToken
-    }
-    const expandOp = page.expand(
-      () => {
-        if (!hasMore) {
-          hasMore = false
-          return Observable.of(sampleHasNoMoreResponse)
+  describe(`${page.expand.name}(`, () => {
+    it(`should complete on source$ completion`, function* () {
+      const source$ = Observable.empty()
+      const expandOp = page.expand(
+        () => Observable.of(sampleResponse),
+        page.acc,
+        page.defaultState<number>('')
+      )
+      let isCompleted = false
+      yield source$.pipe(expandOp).mergeAll().do({
+        complete: () => {
+          isCompleted = true
         }
-        return Observable.of(sampleResponse)
-      },
-      page.accumulateResultByConcat,
-      page.defaultState('')
-    )
-    let isCompleted = false
-    const infiniteSource$ = Observable.interval()
-    yield infiniteSource$.pipe(expandOp).mergeAll().do({
-      complete: () => {
-        isCompleted = true
-      }
-    }).take(10) // 避免出错时，由 infiniteSource$ 造成的无限溢出的问题
-    yield Observable.of(isCompleted)
-      .do((x) => {
-        expect(x).to.be.true
       })
-  })
-
-  it(`${page.expand.name} should error on source$ error`, function* () {
-    const sampleError = new Error('source$ error')
-    const source$ = Observable.throw(sampleError)
-    const expandOp = page.expand(
-      () => Observable.of(sampleResponse),
-      page.accumulateResultByConcat,
-      page.defaultState('')
-    )
-    let isErrorPassedThrough = false
-    yield source$.pipe(expandOp).mergeAll().do({
-      error: () => {
-        isErrorPassedThrough = true
-      }
-    }).catch(() => Observable.empty())
-    yield Observable.of(isErrorPassedThrough)
-      .do((x) => {
-        expect(x).to.be.true
-      })
-  })
-
-  it(`${page.expand.name} should allow retry on source$ error`, function* () {
-    const sampleError = new Error('source$ error')
-    let hasThrown = false
-    const source$ = Observable.of('fail at first, succeed for the rest').do(() => {
-      if (!hasThrown) {
-        hasThrown = true
-        throw sampleError
-      }
+      yield Observable.of(isCompleted)
+        .do((x) => {
+          expect(x).to.be.true
+        })
     })
-    const expandOp = page.expand(
-      () => Observable.of(sampleResponse),
-      page.accumulateResultByConcat,
-      page.defaultState('')
-    )
-    yield source$.pipe(expandOp).mergeAll().do((x) => {
-      expect(x.nextPageToken).to.equal('456')
-      expect(x.result.slice(-pageSize)).to.deep.equal([1, 2, 3])
-    }).retry(2)
-  })
 
-  // todo(dingwen): use marble test instead
-  it(`${page.expand.name} should ignore source$ when the current load is yet to be completed`, function* () {
-    const source$ = Observable.interval(10).take(3)
-    const expandOp = page.expand(
-      () => Observable.of(sampleResponse).delay(25),
-      page.accumulateResultByConcat,
-      page.defaultState('')
-    )
-    const page$ = source$.pipe(expandOp).mergeAll().publishReplay(1).refCount()
+    it(`should complete on hasMore: false`, function* () {
+      let hasMore = true
+      const sampleHasNoMoreResponse = {
+        result: [4, 5, 6],
+        nextPageToken: page.emptyPageToken
+      }
+      const expandOp = page.expand(
+        () => {
+          if (!hasMore) {
+            hasMore = false
+            return Observable.of(sampleHasNoMoreResponse)
+          }
+          return Observable.of(sampleResponse)
+        },
+        page.acc,
+        page.defaultState<number>('')
+      )
+      let isCompleted = false
+      const infiniteSource$ = Observable.interval()
+      yield infiniteSource$.pipe(expandOp).mergeAll().do({
+        complete: () => {
+          isCompleted = true
+        }
+      }).take(10) // 避免出错时，由 infiniteSource$ 造成的无限溢出的问题
+      yield Observable.of(isCompleted)
+        .do((x) => {
+          expect(x).to.be.true
+        })
+    })
 
-    let earliestFirst: any = null
-    const earliestFirst$ = page$.takeUntil(Observable.timer(40))
-    yield earliestFirst$
-      .do((x) => {
-        earliestFirst = x
-      })
-    yield Observable.of(earliestFirst)
-      .do((x) => {
-        expect(x.result).to.deep.equal([1, 2, 3])
-      })
+    it(`should error on source$ error`, function* () {
+      const sampleError = new Error('source$ error')
+      const source$ = Observable.throw(sampleError)
+      const expandOp = page.expand(
+        () => Observable.of(sampleResponse),
+        page.acc,
+        page.defaultState<number>('')
+      )
+      let isErrorPassedThrough = false
+      yield source$.pipe(expandOp).mergeAll().do({
+        error: () => {
+          isErrorPassedThrough = true
+        }
+      }).catch(() => Observable.empty())
+      yield Observable.of(isErrorPassedThrough)
+        .do((x) => {
+          expect(x).to.be.true
+        })
+    })
 
-    let emitOnlyOnce: any = null
-    const emitOnlyOnce$ = page$.takeUntil(Observable.timer(60))
-    yield emitOnlyOnce$
-      .do((x) => {
-        emitOnlyOnce = x
-      })
-    yield Observable.of(emitOnlyOnce)
-      .do((x) => {
-        expect(x.result).to.deep.equal([1, 2, 3])
-      })
-  })
-
-  it(`${page.expand.name} should not block second load when the first load has failed`, function* () {
-    const sampleError = new Error('first load failed')
-    let hasThrown = false
-    const expandOp = page.expand(
-      () => {
+    it(`should allow retry on source$ error`, function* () {
+      const sampleError = new Error('source$ error')
+      let hasThrown = false
+      const source$ = Observable.of('fail at first, succeed for the rest').do(() => {
         if (!hasThrown) {
           hasThrown = true
-          return Observable.throw(sampleError)
+          throw sampleError
         }
-        return Observable.of(sampleResponse)
-      },
-      page.accumulateResultByConcat,
-      page.defaultState('')
-    )
-    yield Observable.from(['first load', 'second load'])
-      .pipe(expandOp)
-      .mergeMap((stream) => stream.catch(() => Observable.empty()))
-      .take(1)
-      .subscribeOn(Scheduler.asap)
-      .do((state: any) => {
-        expect(state.nextPageToken).to.equal(sampleResponse.nextPageToken)
-        expect(state.result.slice(-pageSize)).to.deep.equal(sampleResponse.result)
       })
-  })
+      const expandOp = page.expand(
+        () => Observable.of(sampleResponse),
+        page.acc,
+        page.defaultState<number>('')
+      )
+      yield source$.pipe(expandOp).mergeAll().do((x) => {
+        expect(x.nextPageToken).to.equal('456')
+        expect(x.result.slice(-pageSize)).to.deep.equal([1, 2, 3])
+      }).retry(2)
+    })
 
-  it(`${page.expand.name} should not block next load when current load has failed`, function* () {
-    const sampleError = new Error('current load failed')
-    const sampleNextResponse = {
-      result: [4, 5, 6],
-      nextPageToken: '789' as page.PageToken
-    }
-    let hasThrown = false
-    const expandOp = page.expand(
-      () => {
-        if (!hasThrown) {
-          hasThrown = true
-          return Observable.throw(sampleError)
-        }
-        return Observable.of(sampleNextResponse)
-      },
-      page.accumulateResultByConcat,
-      {
-        ...page.defaultState(''),
-        nextPage: 2,
-        nextPageToken: '456' as page.PageToken,
-        result: [1, 2, 3]
+    // todo(dingwen): use marble test instead
+    it(`should ignore source$ when the current load is yet to be completed`, function* () {
+      const source$ = Observable.interval(10).take(3)
+      const expandOp = page.expand(
+        () => Observable.of(sampleResponse).delay(25),
+        page.acc,
+        page.defaultState<number>('')
+      )
+      const page$ = source$.pipe(expandOp).mergeAll().publishReplay(1).refCount()
+
+      let earliestFirst: any = null
+      const earliestFirst$ = page$.takeUntil(Observable.timer(40))
+      yield earliestFirst$
+        .do((x) => {
+          earliestFirst = x
+        })
+      yield Observable.of(earliestFirst)
+        .do((x) => {
+          expect(x.result).to.deep.equal([1, 2, 3])
+        })
+
+      let emitOnlyOnce: any = null
+      const emitOnlyOnce$ = page$.takeUntil(Observable.timer(60))
+      yield emitOnlyOnce$
+        .do((x) => {
+          emitOnlyOnce = x
+        })
+      yield Observable.of(emitOnlyOnce)
+        .do((x) => {
+          expect(x.result).to.deep.equal([1, 2, 3])
+        })
+    })
+
+    it(`should not block second load when the first load has failed`, function* () {
+      const sampleError = new Error('first load failed')
+      let hasThrown = false
+      const expandOp = page.expand(
+        () => {
+          if (!hasThrown) {
+            hasThrown = true
+            return Observable.throw(sampleError)
+          }
+          return Observable.of(sampleResponse)
+        },
+        page.acc,
+        page.defaultState<number>('')
+      )
+      yield Observable.from(['first load', 'second load'])
+        .pipe(expandOp)
+        .mergeMap((stream) => stream.catch(() => Observable.empty()))
+        .take(1)
+        .subscribeOn(Scheduler.asap)
+        .do((state: any) => {
+          expect(state.nextPageToken).to.equal(sampleResponse.nextPageToken)
+          expect(state.result.slice(-pageSize)).to.deep.equal(sampleResponse.result)
+        })
+    })
+
+    it(`should not block next load when current load has failed`, function* () {
+      const sampleError = new Error('current load failed')
+      const sampleNextResponse = {
+        result: [4, 5, 6],
+        nextPageToken: '789' as page.PageToken
       }
-    )
-    yield Observable.from(['current load', 'next load'])
-      .pipe(expandOp)
-      .mergeMap((stream) => stream.catch(() => Observable.empty()))
-      .take(1)
-      .subscribeOn(Scheduler.asap)
-      .do((state: any) => {
-        expect(state.nextPageToken).to.equal(sampleNextResponse.nextPageToken)
-        expect(state.result.slice(-pageSize)).to.deep.equal(sampleNextResponse.result)
-      })
+      let hasThrown = false
+      const expandOp = page.expand(
+        () => {
+          if (!hasThrown) {
+            hasThrown = true
+            return Observable.throw(sampleError)
+          }
+          return Observable.of(sampleNextResponse)
+        },
+        page.acc,
+        {
+          ...page.defaultState(''),
+          nextPage: 2,
+          nextPageToken: '456' as page.PageToken,
+          result: [1, 2, 3]
+        }
+      )
+      yield Observable.from(['current load', 'next load'])
+        .pipe(expandOp)
+        .mergeMap((stream) => stream.catch(() => Observable.empty()))
+        .take(1)
+        .subscribeOn(Scheduler.asap)
+        .do((state: any) => {
+          expect(state.nextPageToken).to.equal(sampleNextResponse.nextPageToken)
+          expect(state.result.slice(-pageSize)).to.deep.equal(sampleNextResponse.result)
+        })
+    })
   })
-
 })
 
 describe(`${expandPage.name}`, () => {
@@ -225,6 +266,10 @@ describe(`${expandPage.name}`, () => {
   const apiHost = 'https://www.teambition.com/api'
   const urlPath = 'task'
   const testUrl = `${apiHost}/${urlPath}`
+  const pageSize = 5
+  const initStateA = Object.freeze(page.defaultState(urlPath, { pageSize, kind: page.Kind.PageCount }))
+  const initStateB = Object.freeze(page.defaultState(urlPath, { pageSize, kind: page.Kind.PageToken }))
+  const initStates = [initStateA, initStateB]
 
   beforeEach(() => {
     sdkFetch = new SDKFetch(apiHost)
@@ -234,115 +279,306 @@ describe(`${expandPage.name}`, () => {
     fetchMock.restore()
   })
 
-  it('should not emit new state when request fails', () => {
-    fetchMock.get(new RegExp(testUrl), { status: 404 })
+  initStates.forEach((state) => {
+    it(`state kind ${state.kind}: should not emit new state when request fails`, () => {
+      fetchMock.get(new RegExp(testUrl), { status: 404 })
 
-    const initial = page.defaultState(urlPath, { pageSize: 5 })
-    return sdkFetch.expandPage(initial)
+      return sdkFetch.expandPage(state)
+        .toPromise()
+        .then(() => {
+          throw new Error('should not emit new state when request fails')
+        })
+        .catch((err) => {
+          expect(err.error.status).to.equal(404)
+        })
+    })
+  })
+
+  it(`state kind ${page.Kind.PageCount}: should emit new state (based on initial state) on successful request`, () => {
+    fetchMock.get(new RegExp(testUrl), [1, 2, 3, 4, 5])
+
+    return sdkFetch.expandPage(initStateA)
+      .take(1)
       .toPromise()
-      .then(() => {
-        throw new Error('should not emit new state when request fails')
-      })
-      .catch((err) => {
-        expect(err.error.status).to.equal(404)
+      .then((resultState) => {
+        expect(resultState).to.deep.equal({
+          kind: page.Kind.PageCount,
+          urlPath,
+          result: [1, 2, 3, 4, 5],
+          nextPage: 2,
+          hasMore: true,
+          pageSize: 5,
+          urlQuery: undefined,
+          limit: 5
+        })
       })
   })
 
-  it('should emit new state (based on initial state) on successful request', () => {
+  it(`state kind ${page.Kind.PageToken}: should emit new state (based on initial state) on successful request`, () => {
     fetchMock.get(new RegExp(testUrl), {
       nextPageToken: 'asdf',
       totalSize: 66,
       result: [1, 2, 3, 4, 5]
     })
 
-    const initial = page.defaultState(urlPath, { pageSize: 5 })
-    return sdkFetch.expandPage(initial)
+    return sdkFetch.expandPage(initStateB)
       .take(1)
       .toPromise()
       .then((resultState) => {
         expect(resultState).to.deep.equal({
+          kind: page.Kind.PageToken,
           urlPath,
           nextPageToken: 'asdf',
           totalSize: 66,
           result: [1, 2, 3, 4, 5],
           nextPage: 2,
           hasMore: true,
-          pageSize: 5
+          pageSize: 5,
+          urlQuery: undefined,
+          limit: 5
         })
       })
   })
 
-  it('should emit new state (based on non-initial state) on successful request', () => {
-    fetchMock.get(new RegExp(testUrl), {
-      nextPageToken: 'ghjk',
-      totalSize: 66,
-      result: [6, 7, 8, 9, 10]
-    })
+  it(`state kind ${page.Kind.PageCount}: should emit new state (based on non-initial state) on successful request`, () => {
+    fetchMock.get(new RegExp(testUrl), [6, 7, 8, 9, 10])
 
-    const currState: page.State = {
+    const currState: page.PageCountState = {
+      kind: page.Kind.PageCount,
       urlPath,
-      nextPageToken: 'asdf' as page.PageToken,
-      totalSize: 66,
       result: [1, 2, 3, 4, 5],
       nextPage: 2,
       hasMore: true,
-      pageSize: 5
+      pageSize: 5,
+      limit: 5,
+      urlQuery: undefined
     }
     return sdkFetch.expandPage(currState)
       .take(1)
       .toPromise()
       .then((resultState) => {
         expect(resultState).to.deep.equal({
+          kind: page.Kind.PageCount,
           urlPath: urlPath,
-          nextPageToken: 'ghjk',
-          totalSize: 66,
           result: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
           nextPage: 3,
           hasMore: true,
-          pageSize: 5
+          pageSize: 5,
+          urlQuery: undefined,
+          limit: 10
         })
       })
   })
 
-  it('should mutate state on successful request on options.mutate: true', () => {
-    fetchMock.get(new RegExp(testUrl), {
-      nextPageToken: 'asdf',
-      totalSize: 66,
-      result: [1, 2, 3, 4, 5]
-    })
-
-    const initial = page.defaultState(urlPath, { pageSize: 5 })
-    return sdkFetch.expandPage(initial, { mutate: true })
-      .take(1)
-      .toPromise()
-      .then(() => {
-        expect(initial).to.deep.equal({
-          urlPath,
-          nextPageToken: 'asdf',
-          totalSize: 66,
-          result: [1, 2, 3, 4, 5],
-          nextPage: 2,
-          hasMore: true,
-          pageSize: 5
-        })
-      })
-  })
-
-  it('should allow mapFn to be applied to all the items in result', () => {
+  it(`state kind ${page.Kind.PageToken}: should emit new state (based on non-initial state) on successful request`, () => {
     fetchMock.get(new RegExp(testUrl), {
       nextPageToken: 'ghjk',
       totalSize: 66,
       result: [6, 7, 8, 9, 10]
     })
 
-    const currState: page.State<number> = {
+    const currState: page.PageTokenState = {
+      kind: page.Kind.PageToken,
       urlPath,
       nextPageToken: 'asdf' as page.PageToken,
       totalSize: 66,
+      result: [1, 2, 3, 4, 5],
+      nextPage: 2,
+      hasMore: true,
+      pageSize: 5,
+      limit: 5,
+      urlQuery: undefined
+    }
+    return sdkFetch.expandPage(currState)
+      .take(1)
+      .toPromise()
+      .then((resultState) => {
+        expect(resultState).to.deep.equal({
+          kind: page.Kind.PageToken,
+          urlPath: urlPath,
+          nextPageToken: 'ghjk',
+          totalSize: 66,
+          result: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+          nextPage: 3,
+          hasMore: true,
+          pageSize: 5,
+          urlQuery: undefined,
+          limit: 10
+        })
+      })
+  })
+
+  it(`state kind ${page.Kind.PageCount}: should expand on options.loadMore$`, function* () {
+    fetchMock.get(new RegExp(testUrl), (url, options) => {
+      const pageNums = ['1', '2', '3']
+      const i = url.indexOf('?')
+      const qs = url.slice(i + 1)
+      const q = querystring.parse(qs)
+      const page = pageNums.indexOf(q.page)
+      const step = page * pageSize
+      return [1,2,3,4,5].map((x) => x + step)
+    })
+
+    const stream$ = sdkFetch.expandPage(initStateA, {
+      loadMore$: Observable.from(['page 1', 'page 2', 'page 3'])
+    })
+
+    yield stream$.take(1)
+      .do((x) => {
+        expect(x.nextPage).to.equal(2)
+        expect(x.result).to.deep.equal([1, 2, 3, 4, 5])
+      })
+
+    yield stream$.take(1)
+      .do((x) => {
+        expect(x.nextPage).to.equal(3)
+        expect(x.result).to.deep.equal([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+      })
+
+    yield stream$.take(1)
+      .do((x) => {
+        expect(x.nextPage).to.equal(4)
+        expect(x.result).to.deep.equal([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+      })
+  })
+
+  it(`state kind ${page.Kind.PageToken}: should expand on options.loadMore$`, function* () {
+    fetchMock.get(new RegExp(testUrl), (url, options) => {
+      const pageTokens = ['', 'a', 'b', 'c']
+      const i = url.indexOf('?')
+      const qs = url.slice(i + 1)
+      const q = querystring.parse(qs)
+      const page = pageTokens.indexOf(q.pageToken)
+      const step = page * pageSize
+      return {
+        nextPageToken: pageTokens[page + 1],
+        result: [1,2,3,4,5].map((x) => x + step)
+      }
+    })
+
+    const stream$ = sdkFetch.expandPage(initStateB, {
+      loadMore$: Observable.from(['page 1', 'page 2', 'page 3'])
+    })
+
+    yield stream$.take(1)
+      .do((x) => {
+        expect(x.nextPage).to.equal(2)
+        expect(x.result).to.deep.equal([1, 2, 3, 4, 5])
+        expect(x.nextPageToken).to.equal('a')
+      })
+
+    yield stream$.take(1)
+      .do((x) => {
+        expect(x.nextPage).to.equal(3)
+        expect(x.result).to.deep.equal([1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        expect(x.nextPageToken).to.equal('b')
+      })
+
+    yield stream$.take(1)
+      .do((x) => {
+        expect(x.nextPage).to.equal(4)
+        expect(x.result).to.deep.equal([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15])
+        expect(x.nextPageToken).to.equal('c')
+      })
+  })
+
+  it(`state kind ${page.Kind.PageCount}: should disable default concat behavior on options.doNotConcat: true`, () => {
+    fetchMock.get(new RegExp(testUrl), [6, 7, 8, 9, 10])
+
+    const currState: page.PageCountState = {
+      kind: page.Kind.PageCount,
+      urlPath,
+      result: [1, 2, 3, 4, 5],
+      nextPage: 2,
+      hasMore: true,
+      pageSize: 5,
+      limit: 5,
+      urlQuery: undefined
+    }
+    return sdkFetch.expandPage(currState, { skipConcat: true })
+      .take(1)
+      .toPromise()
+      .then((resultState) => {
+        expect(resultState.result).to.deep.equal([6, 7, 8, 9, 10])
+        expect(resultState.limit).to.equal(10)
+        expect(resultState.nextPage).to.equal(3)
+        expect(resultState.hasMore).to.be.true
+      })
+  })
+
+  it(`state kind ${page.Kind.PageToken}: should disable default concat behavior on options.doNotConcat: true`, () => {
+    fetchMock.get(new RegExp(testUrl), {
+      nextPageToken: 'ghjk',
+      totalSize: 66,
+      result: [6, 7, 8, 9, 10]
+    })
+
+    const currState: page.PageTokenState = {
+      kind: page.Kind.PageToken,
+      urlPath,
+      nextPageToken: 'asdf' as page.PageToken,
+      totalSize: 66,
+      result: [1, 2, 3, 4, 5],
+      nextPage: 2,
+      hasMore: true,
+      pageSize: 5,
+      limit: 5,
+      urlQuery: undefined
+    }
+    return sdkFetch.expandPage(currState, { skipConcat: true })
+      .take(1)
+      .toPromise()
+      .then((resultState) => {
+        expect(resultState.result).to.deep.equal([6, 7, 8, 9, 10])
+        expect(resultState.limit).to.equal(10)
+        expect(resultState.nextPage).to.equal(3)
+        expect(resultState.hasMore).to.be.true
+      })
+  })
+
+  it(`state kind ${page.Kind.PageCount}: should mutate state on successful request on options.mutate: true`, () => {
+    fetchMock.get(new RegExp(testUrl), [1, 2, 3, 4])
+    const initial = { ...initStateA }
+    return sdkFetch.expandPage(initial, { mutate: true })
+      .take(1)
+      .toPromise()
+      .then(() => {
+        expect(initial.nextPage).to.equal(2)
+        expect(initial.result).to.deep.equal([1, 2, 3, 4])
+        expect(initial.hasMore).to.be.false
+      })
+  })
+
+  it(`state kind ${page.Kind.PageToken}: should mutate state on successful request on options.mutate: true`, () => {
+    fetchMock.get(new RegExp(testUrl), {
+      nextPageToken: 'asdf',
+      totalSize: 4,
+      result: [1, 2, 3, 4]
+    })
+    const initial = { ...initStateB }
+    return sdkFetch.expandPage(initial, { mutate: true })
+      .take(1)
+      .toPromise()
+      .then(() => {
+        expect(initial.nextPageToken).to.equal('asdf')
+        expect(initial.totalSize).to.equal(4)
+        expect(initial.nextPage).to.equal(2)
+        expect(initial.result).to.deep.equal([1, 2, 3, 4])
+        expect(initial.hasMore).to.be.false
+      })
+  })
+
+  it(`state kind ${page.Kind.PageCount}: should allow mapFn to be applied to all the items in result`, () => {
+    fetchMock.get(new RegExp(testUrl), [6, 7, 8, 9, 10])
+
+    const currState: page.PageCountState<number> = {
+      kind: page.Kind.PageCount,
+      urlPath,
       result: [0, 1, 2, 3, 4],
       nextPage: 2,
       hasMore: true,
-      pageSize: 5
+      pageSize: 5,
+      limit: 5
     }
     return sdkFetch.expandPage<number>(currState, {
       urlQuery: {},
@@ -351,15 +587,36 @@ describe(`${expandPage.name}`, () => {
       .take(1)
       .toPromise()
       .then((resultState) => {
-        expect(resultState).to.deep.equal({
-          urlPath,
-          nextPageToken: 'ghjk',
-          totalSize: 66,
-          result: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
-          nextPage: 3,
-          hasMore: true,
-          pageSize: 5
-        })
+        expect(resultState.result).to.deep.equal([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+      })
+  })
+
+  it(`state kind ${page.Kind.PageToken}: should allow mapFn to be applied to all the items in result`, () => {
+    fetchMock.get(new RegExp(testUrl), {
+      nextPageToken: 'ghjk',
+      totalSize: 66,
+      result: [6, 7, 8, 9, 10]
+    })
+
+    const currState: page.PageTokenState<number> = {
+      kind: page.Kind.PageToken,
+      urlPath,
+      nextPageToken: 'asdf' as page.PageToken,
+      totalSize: 66,
+      result: [0, 1, 2, 3, 4],
+      nextPage: 2,
+      hasMore: true,
+      pageSize: 5,
+      limit: 5
+    }
+    return sdkFetch.expandPage<number>(currState, {
+      urlQuery: {},
+      mapFn: (i) => i - 1
+    })
+      .take(1)
+      .toPromise()
+      .then((resultState) => {
+        expect(resultState.result).to.deep.equal([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
       })
   })
 
@@ -373,7 +630,8 @@ describe(`${expandPage.name}`, () => {
       }
     })
 
-    const currState: page.State<{ value: number, sessionId: string }> = {
+    const currState: page.PageTokenState<{ value: number, sessionId: string }> = {
+      kind: page.Kind.PageToken,
       urlPath,
       nextPageToken: 'asdf' as page.PageToken,
       totalSize: 66,
@@ -386,7 +644,8 @@ describe(`${expandPage.name}`, () => {
       ],
       nextPage: 2,
       hasMore: true,
-      pageSize: 5
+      pageSize: 5,
+      limit: 5
     }
     return sdkFetch.expandPage<number, { value: number, sessionId: string }>(
       currState,
@@ -402,6 +661,7 @@ describe(`${expandPage.name}`, () => {
       .toPromise()
       .then((resultState) => {
         expect(resultState).to.deep.equal({
+          kind: page.Kind.PageToken,
           urlPath,
           nextPageToken: 'ghjk',
           totalSize: 66,
@@ -419,8 +679,23 @@ describe(`${expandPage.name}`, () => {
           ],
           nextPage: 3,
           hasMore: true,
-          pageSize: 5
+          pageSize: 5,
+          limit: 10
         })
       })
   })
+
+  it(`should 'pass-through' state of undefined kind`, () => {
+    fetchMock.get(new RegExp(testUrl), [1, 2, 3, 4, 5])
+
+    const { kind, ...initial } = initStateA
+
+    return sdkFetch.expandPage(initial as any)
+      .take(1)
+      .toPromise()
+      .then((x) => {
+        expect(x).to.deep.equal(initial)
+      })
+  })
+
 })


### PR DESCRIPTION
添加 `PageCountState` 类型状态，原来的分页状态定义为 `PageTokenState`（原来的 `State` 指向 `PageTokenState`）。并在相关逻辑内支持 `PageCountState` 需要的特有逻辑。

另外，在状态中补充管理 `limit` 字段，用于方便用户对结果数据做缓存访问。并补充一个衔接 fetch 接口与 缓存接口 的工具函数，`Page.queryInfo`。

- [x] 补充测试

TODO: ~~为 wiki 文章补充相关 section~~[另提 PR]