### PR TITLE
refactor(Net): 引入 rxjs delayWhen 操作符，令部分逻辑表达更明确

### DIFF
--- a/src/Net/Net.ts
+++ b/src/Net/Net.ts
@@ -1,9 +1,9 @@
 import 'rxjs/add/observable/forkJoin'
 import 'rxjs/add/observable/of'
 import 'rxjs/add/operator/concatAll'
+import 'rxjs/add/operator/delayWhen'
 import 'rxjs/add/operator/do'
-import 'rxjs/add/operator/last'
-import 'rxjs/add/operator/mapTo'
+import 'rxjs/add/operator/materialize'
 import 'rxjs/add/operator/mergeMap'
 import 'rxjs/add/operator/switchMap'
 import 'rxjs/add/operator/filter'
@@ -13,7 +13,7 @@ import { BehaviorSubject } from 'rxjs/BehaviorSubject'
 import { exhaustMap } from 'rxjs/operators/exhaustMap'
 import { QueryToken, SelectorMeta, ProxySelector } from 'reactivedb/proxy'
 import { JoinMode } from 'reactivedb/interface'
-import { Database, Query, Predicate, ExecutorResult } from 'reactivedb'
+import { Database, Query, Predicate } from 'reactivedb'
 
 import { forEach, isNonNullable, ParsedWSMsg, WSMsgToDBHandler, GeneralSchemaDef } from '../utils'
 import { SDKLogger } from '../utils/Logger'
@@ -72,6 +72,10 @@ export interface ApiResult<T, U extends CacheStrategy> {
   query: Query<T>
   tableName: string
   cacheValidate: U
+  /**
+   * 设定必须有值（非 undefined）的字段，在数据层尽可能
+   * 保证推出的数据有这些字段。请搭配 padding 字段使用。
+   */
   required?: (keyof T)[]
   /**
    * 指定需要关联其他数据模型（M）查询获得的字段，以及
@@ -89,6 +93,13 @@ export interface ApiResult<T, U extends CacheStrategy> {
    * 或为空（[]）。
    */
   excludeFields?: string[]
+  /**
+   * 与 required 字段搭配使用，用于补充数据（确保
+   * required 字段有值）。当 required 中的字段缺值
+   * （undefined），会使用提供的 padding 函数去获取完整
+   * 数据。注意：请确保 padding 函数返回的 Observable 有
+   * 异常处理机制（catch）。
+   */
   padding?: (missedId: string) => Observable<T | null>
 }
 
@@ -143,8 +154,8 @@ const fieldsPred =
     }
   }
 
-const hasFields = <T>(datum: T, fields: Array<keyof T>) =>
-  fields.every((field) => typeof datum[field] !== 'undefined')
+const missingFieldsChecker = <T>(fields: Array<keyof T>) => (item: T) =>
+  fields.some((field) => typeof item[field] === 'undefined')
 
 export class Net {
   public fields = new Map<string, string[]>()
@@ -164,22 +175,19 @@ export class Net {
     if (!required || !padding || !pk) {
       fn = (stream$) => stream$ // pass through
     } else {
+      const hasMissingFields = missingFieldsChecker(required)
       fn = exhaustMap((resultSet) => {
-        if (!resultSet.length) {
-          return Observable.of(resultSet)
-        }
-        return Observable.from(resultSet)
-          .mergeMap((resultItem) => {
-            if (hasFields(resultItem, required)) {
-              return Observable.of(resultItem)
-            }
-            return padding(resultItem[pk])
+        const padding$ = Observable
+          .from(resultSet.filter(hasMissingFields))
+          .mergeMap((x) => {
+            return padding(x[pk])
               .filter(isNonNullable)
-              .concatMap((resp) => this.database!.upsert(tableName, resp).mapTo(resp))
-              .do((resp) => Object.assign(resultItem, resp))
+              .delayWhen((resp) => this.database!.upsert(tableName, resp))
+              .do((resp) => Object.assign(x, resp)) // side-effect
           })
-          .last()
-          .mapTo(resultSet)
+        return Observable
+          .of(resultSet)
+          .delayWhen(() => padding$.materialize().takeLast(1))
       })
     }
     fn.toString = () => 'SDK_VALIDATE'
@@ -241,24 +249,19 @@ export class Net {
     const database = this.database!
 
     const { request, method, tableName } = result as CUDApiResult<T>
-    let destination: Observable<ExecutorResult> | Observable<T | T[]>
-    return request
-      .concatMap(v => {
-        switch (method) {
-          case 'create':
-            destination = database.upsert<T>(tableName, v)
-            break
-          case 'update':
-            destination = database.upsert(tableName, v)
-            break
-          case 'delete':
-            destination = database.delete<T>(tableName, (result as UDResult<T>).clause)
-            break
-          default:
-            throw new Error()
-        }
-        return destination.mapTo<ExecutorResult | T | T[], T>(v)
-      })
+
+    return request.delayWhen((v) => {
+      switch (method) {
+        case 'create':
+          return database.upsert<T>(tableName, v)
+        case 'update':
+          return database.upsert(tableName, v)
+        case 'delete':
+          return database.delete<T>(tableName, (result as UDResult<T>).clause)
+        default:
+          throw new Error()
+      }
+    })
   }
 
   persist(database: Database) {
@@ -375,7 +378,7 @@ export class Net {
         if (!requestCache) {
           /*tslint:disable no-shadowed-variable*/
           const selector$ = response$
-            .concatMap(v => database.upsert(tableName, v))
+            .delayWhen((v) => database.upsert(tableName, v))
             .do(() => this.requestMap.set(cacheKey, true))
             .concatMap(() => dbGetWithSelfJoinEnabled<T>(database, tableName, q).selector$)
           token = new QueryToken(selector$)
@@ -386,7 +389,7 @@ export class Net {
         break
       case CacheStrategy.Cache:
         const selector$ = response$
-          .concatMap(v => database.upsert(tableName, v))
+          .delayWhen((v) => database.upsert(tableName, v))
           .concatMap(() => dbGetWithSelfJoinEnabled<T>(database, tableName, q).selector$)
         return new QueryToken(selector$)
       default:

--- a/test/net/net.ts
+++ b/test/net/net.ts
@@ -527,6 +527,20 @@ describe('Net test', () => {
         })
     })
 
+    it('should pass-through all-complete result set (without padding requests)', function* () {
+      const completeEvent = { ...sampleEvent, ...partialEvent }
+
+      mockEventsGet(_projectId, [ completeEvent ])
+
+      yield net.lift(getEventsWithRequired(sdkFetch, _projectId)).changes()
+        .subscribeOn(Scheduler.asap)
+        .take(1)
+        .do(([ event ]) => {
+          expect(spyFetch.callCount).to.equal(1)
+          expectToDeepEqualForFieldsOfTheExpected(event, completeEvent)
+        })
+    })
+
     it('padding: should emit once for one change update on a result set of size >= 2', function* () {
       mockEventsGet(_projectId, [])
 


### PR DESCRIPTION
用 delayWhen 代替代码里一些使用 concatMap 来做时延但其实不需要结果值的场景。令相关代码语义更明确。

另外，在上边修改涉及到的 padding 机制代码做结构调整，令其更清晰。

Thanks to @DomonJi !

- [x] 检查一下，看有没有涉及没被单元测试覆盖的代码的修改，尝试完善相应测试。

...to resolve #574 