### PR TITLE
fix(schemas): 纠正 TaskSchema `project` 字段为可选字段

### DIFF
--- a/src/schemas/Task.ts
+++ b/src/schemas/Task.ts
@@ -80,7 +80,7 @@ export interface TaskSchema {
   objectType: 'task'
   type: 'task' // todo(dingwen): deprecate
   isFavorite: boolean,
-  project: Pick<ProjectSchema, '_id' | 'name'>,
+  project?: Pick<ProjectSchema, '_id' | 'name'>,
   uniqueId: number
   url: string
   workTime: {


### PR DESCRIPTION
...这个字段一般只在搜索接口的结果中直接使用，其他场景少有存在的。

Thanks to @AmosJin @aicest !

...resolves #588 