### PR TITLE
feat(schemas/SmartGroup): 支持自定义筛选视图

### DIFF
--- a/src/schemas/SmartGroup.ts
+++ b/src/schemas/SmartGroup.ts
@@ -5,6 +5,7 @@ import {
   SmartGroupId,
   SmartGroupViewType,
   SwimAxisLane,
+  SmartGroupPredefinedIcon,
   SmartGroupType,
 } from 'teambition-types'
 import { schemaColl } from './schemas'
@@ -15,6 +16,7 @@ export interface SmartGroupSchema {
   _creatorId: UserId
   name: string
   description: string
+  icon: SmartGroupPredefinedIcon | null
   taskCount?: {
     total: number
   }
@@ -47,6 +49,9 @@ const schema: SchemaDef<SmartGroupSchema> = {
     type: RDBType.STRING,
   },
   filter: {
+    type: RDBType.STRING,
+  },
+  icon: {
     type: RDBType.STRING,
   },
   name: {

--- a/src/schemas/SmartGroup.ts
+++ b/src/schemas/SmartGroup.ts
@@ -1,13 +1,14 @@
 import { RDBType, SchemaDef } from 'reactivedb/interface'
 import {
+  BoardAxisType,
   ProjectId,
-  UserId,
   SmartGroupId,
   SmartGroupViewType,
-  SwimAxisLane,
   SmartGroupPredefinedIcon,
   SmartGroupType,
-  TaskSortMethod
+  TaskSortMethod,
+  TaskflowId,
+  UserId,
 } from 'teambition-types'
 import { schemaColl } from './schemas'
 
@@ -24,8 +25,10 @@ export interface SmartGroupSchema {
   type?: SmartGroupType
   view: {
     type: SmartGroupViewType
-    vertical?: SwimAxisLane
-    horizontal?: SwimAxisLane
+    vertical?: BoardAxisType
+    horizontal?: BoardAxisType
+    _verticalId?: TaskflowId
+    _horizontalId?: TaskflowId
   },
   orderBy?: TaskSortMethod
   filter: string

--- a/src/schemas/SmartGroup.ts
+++ b/src/schemas/SmartGroup.ts
@@ -7,6 +7,7 @@ import {
   SwimAxisLane,
   SmartGroupPredefinedIcon,
   SmartGroupType,
+  TaskSortMethod
 } from 'teambition-types'
 import { schemaColl } from './schemas'
 
@@ -23,9 +24,10 @@ export interface SmartGroupSchema {
   type?: SmartGroupType
   view: {
     type: SmartGroupViewType
-    vertical: SwimAxisLane
-    horizontal: SwimAxisLane
+    vertical?: SwimAxisLane
+    horizontal?: SwimAxisLane
   },
+  orderBy?: TaskSortMethod
   filter: string
   created: string
   updated: string
@@ -55,6 +57,9 @@ const schema: SchemaDef<SmartGroupSchema> = {
     type: RDBType.STRING,
   },
   name: {
+    type: RDBType.STRING,
+  },
+  orderBy: {
     type: RDBType.STRING,
   },
   taskCount: {

--- a/src/teambition.ts
+++ b/src/teambition.ts
@@ -119,6 +119,7 @@ declare module 'teambition-types' {
   export type TaskSortMethod = 'duedate' | 'priority' | 'created_asc' | 'created_desc' | 'startdate' | 'startdate_desc' | 'custom'
   export type SwimAxisLane = 'sprint' | 'subtask' | 'executor' | 'stage' | 'priority' | 'isDone'
     | 'taskType' | 'rating' | 'storyPoint'
+  export type BoardAxisType = 'iterationSprint' | 'priority' | 'stage' | 'taskflowStatus' | 'taskflow' | 'scenarioConfig'
   export type TagType = 'organization' | 'project'
   export type TaskDependencyKind = 'start_start' | 'start_finish' | 'finish_start' | 'finish_finish'
   export type TaskDivisionType = 'scenariofields' | 'subtasks' | 'links'

--- a/src/teambition.ts
+++ b/src/teambition.ts
@@ -113,8 +113,9 @@ declare module 'teambition-types' {
     | EventOfficialScenarioFieldType
     | TestcaseOfficialScenarioFieldType
   export type ScenarioProTemplateConfigType = 'story' | 'bug' | 'subtask'
-  export type SmartGroupType = 'story' | 'sprint' | 'bug'
-  export type SmartGroupViewType = 'table' | 'time' | 'kanban'
+  export type SmartGroupPredefinedIcon = 'taskToday' | 'taskUndone' | 'taskDone' | 'taskNotAssigned' | 'taskMyExecuted'
+  export type SmartGroupType = 'custom' | 'story' | 'sprint' | 'bug' | 'story.custom' | 'bug.custom' | 'sprint.custom'
+  export type SmartGroupViewType = 'table' | 'time' | 'kanban' | 'list'
   export type TaskSortMethod = 'duedate' | 'priority' | 'created_asc' | 'created_desc' | 'startdate' | 'startdate_desc' | 'custom'
   export type SwimAxisLane = 'sprint' | 'subtask' | 'executor' | 'stage' | 'priority' | 'isDone'
     | 'taskType' | 'rating' | 'storyPoint'


### PR DESCRIPTION
…ewType 字段

icon字段我设置为了string，后端给的是：['taskToday', 'taskUndone', 'taskDone', 'taskNotAssigned', 'taskMyExecuted']。
@chuan6 你觉得前端这里有必要明确的给出这些枚举吗？