### PR TITLE
feat(SocketClient): 提供 getConsumerId() 方法

### DIFF
--- a/src/sockets/SocketClient.ts
+++ b/src/sockets/SocketClient.ts
@@ -12,7 +12,7 @@ import { Observable } from 'rxjs/Observable'
 import { ReplaySubject } from 'rxjs/ReplaySubject'
 import { Net } from '../Net'
 import { Database } from '../db'
-import { SDKFetch } from '../SDKFetch'
+import { SDKFetch, SDKFetchOptions } from '../SDKFetch'
 import { socketHandler, createMsgToDBHandler, createMsgHandler } from './EventMaps'
 import { Interceptors, Proxy } from './Middleware'
 import * as Consumer from 'snapper-consumer'
@@ -154,6 +154,10 @@ export class SocketClient {
     return this._connect()
   }
 
+  getConsumerId() {
+    return this._consumerId
+  }
+
   /**
    * uri 格式: :type/:id
    * eg: projects, organizations/554c83b1b2c809b4715d17b0
@@ -253,19 +257,21 @@ export class SocketClient {
 export function leaveRoom(
   this: SDKFetch,
   room: string,
-  consumerId: string
+  consumerId: string,
+  options?: SDKFetchOptions
 ) {
   // http delete 不允许有 body， 但是这里就是有 body
-  return this.delete<void>(`${room}/subscribe`, { consumerId })
+  return this.delete<void>(`${room}/subscribe`, { consumerId }, options)
     .toPromise()
 }
 
 export function joinRoom(
   this: SDKFetch,
   room: string,
-  consumerId: string
+  consumerId: string,
+  options?: SDKFetchOptions
 ) {
-  return this.post<void>(`${room}/subscribe`, { consumerId })
+  return this.post<void>(`${room}/subscribe`, { consumerId }, options)
     .toPromise()
 }
 


### PR DESCRIPTION
SocketClient join/leave 方法的用户没有设置 `apiHost` 的自由。由于 join 方法的能力受限于内部 _join 所接受的参数，而 _join 所接受的参数由第三方库 snapper-consumer 定（只有 `room` 和 `consumerId` 两个参数），所以没办法拓展 join。

因此选择通过 `getConsumerId()` 方法暴露 consumer id，让用户可以将 consumer id 作为参数传给 SDKFetch 上的 joinRoom/leaveRoom，并利用 joinRoom/leaveRoom 可以灵活设置请求配置的特点，满足用户的需求。

/cc @coldfannn 