### PR TITLE
fix(Net): 令 required/padding 机制应用于 CacheStrategy.Cache

### DIFF
--- a/src/Net/Net.ts
+++ b/src/Net/Net.ts
@@ -385,17 +385,17 @@ export class Net {
         } else {
           token = dbGetWithSelfJoinEnabled<T>(database, tableName, q)
         }
-        token.map(this.validate(result))
         break
       case CacheStrategy.Cache:
         const selector$ = response$
           .delayWhen((v) => database.upsert(tableName, v))
           .concatMap(() => dbGetWithSelfJoinEnabled<T>(database, tableName, q).selector$)
-        return new QueryToken(selector$)
+        token = new QueryToken(selector$)
+        break
       default:
         throw new TypeError('unreachable code path')
     }
-    return token
+    return token.map(this.validate(result))
   }
 
   private getInfoFromResult<T>(result: ApiResult<T, CacheStrategy>) {


### PR DESCRIPTION
之前 required/padding 机制一直遗漏了对 CacheStrategy.Cache 的支持，只
有当使用 CacheStrategy.Request 时 required/padding 机制才被使用到。随
着越来越多应用场景应用 CacheStrategy.Cache，为其补充 required/padding
机制。

/cc @Saviio 

...resolves #622