### PR TITLE
fix(SDKFetch): 避免 get() 方法重复（两次）应用 Http 对象上的 mapFn

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teambition-sdk",
-  "version": "0.12.54",
+  "version": "0.12.55-alpha.5-dedupmapfn",
   "description": "Front-End SDK for Teambition",
   "main": "./index.js",
   "typings": "./index.d.ts",

--- a/src/SDKFetch.ts
+++ b/src/SDKFetch.ts
@@ -118,7 +118,7 @@ export class SDKFetch {
     if (!SDKFetch.FetchStack.has(urlWithQuery)) {
       const tail = SDKFetch.fetchTail || Date.now()
       const urlWithTail = appendQueryString(urlWithQuery, `_=${ tail }`)
-      dist = Observable.defer(() => http.setUrl(urlWithTail).get().send() as any)
+      dist = Observable.defer(() => http.setUrl(urlWithTail).get()['request'])
         .publishReplay<any>(1)
         .refCount()
         .finally(() => {

--- a/test/SDKFetch.spec.ts
+++ b/test/SDKFetch.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai'
 import { Observable, Scheduler } from 'rxjs'
+import { map as rxMap } from 'rxjs/operators'
 import { describe, it, beforeEach, afterEach } from 'tman'
 import { SDK, SDKFetch, forEach, Http, HttpErrorMessage, headers2Object, createSdk } from '.'
 import { clone } from './'
@@ -182,6 +183,18 @@ describe('SDKFetch', () => {
     yield Observable.of(fetchMock.calls(urlMatcher).length)
       .do((numberOfRequestsReceived) => {
         expect(numberOfRequestsReceived).to.equal(2)
+      })
+  })
+
+  it('should only apply `Http` object `mapFn`(internal-use only) once for each request sent', function* () {
+    fetchMock.mock(urlMatcher, { body: 'hello' })
+
+    const httpObj = sdkFetch.get<string>(path, {}, { wrapped: true })
+    httpObj['mapFn'] = rxMap((s) => `${s} world`)
+
+    yield httpObj.send()
+      .do((response) => {
+        expect(response).to.equal('hello world')
       })
   })
 


### PR DESCRIPTION
导致 Http 内部 `request` 流被两次订阅，出现意外重复推出的问题。

这个问题原来没有被发现，是因为没有用户在使用 Http mapFn 这个已经内部化
的功能。而这个问题被发现，是因为在 #621 里纠正了针对异常处理的 mapFn
应用，导致监听 errorAdaptor$ 的用户收到重复报异常。

Thanks to @2eha0 !

/cc @Saviio 