### PR TITLE
fix(apis/scenariofieldconfig): 纠正关联 customfield 字段的机制

### DIFF
--- a/src/apis/scenariofieldconfig/with-custom-fields.ts
+++ b/src/apis/scenariofieldconfig/with-custom-fields.ts
@@ -68,33 +68,64 @@ const normalizeScenarioField = (sdk: SDK) => (
   )
 }
 
+/**
+ * 给 ScenarioField 填充 CustomField 数据
+ *
+ * 后端的 getScenarioFieldConfigs/getOrgScenarioFieldConfigs 接口支持 withCustomfields 参数，
+ * 当 withCustomfields=true 时，会把 CustomField 数据一并返回，挂在 scenarioField.customfield 字段上；
+ * 但后端没有处理 ScenarioFieldConfig 消息推送，推送数据里还是缺少 CustomField 数据，
+ * 不过后端会保证推送 CustomFieldLink 变化，因此可以依赖 scenarioField.customfield + CustomFieldLink 来解决问题，
+ * 这块逻辑相当于将 ScenarioFieldConfig 跟 CustomField 和 CustomFieldLink 进行关联。
+ */
 const getCustomField = (
   sdk: SDK,
   scenarioField: CustomScenarioFieldSchema
 ): Observable<CustomFieldSchema | void> => {
   const empty$ = Observable.of([])
   const customFieldId = scenarioField._customfieldId
+
+  // 自带 CustomField 数据
+  // 1. 当 withCustomfields=true 时，请求接口（getScenarioFieldConfigs/getOrgScenarioFieldConfigs）会返回 CustomField 数据，除非被删
+  // 2. 但 ScenarioFieldConfig 推送数据里，仍是缺失 CustomField 数据
   const customField$ = scenarioField.customfield
     ? Observable.of(scenarioField.customfield)
     : void 0
 
-  // 从企业里请求 CustomField 数据
-  return sdk
-    .getCustomField(customFieldId, { request: customField$ })
-    .changes()
-    .pipe(
+  // 缺少 CustomField 数据，当 CustomField 还存在那么发送请求进行获取
+  const customFieldPadding$ =
+    // 除非 CustomField 没有被删
+    scenarioField.customfield !== null &&
+    // 从企业里请求 CustomField 数据
+    sdk.fetch.getCustomField(customFieldId).pipe(
+      map((resp) => [resp]),
       catchError(() => {
         // 可能不是企业成员，请求数据失败
-        // 那么读取 CustomFieldLink 数据
-        return sdk
-          .getLinkByCustomFieldId(customFieldId, { request: empty$ })
-          .changes()
-          .pipe(
-            map(([link]) => {
-              // 将 CustomFieldLink 当做 CustomField 使用
-              return link ? [linkToCustomField(link) as CustomFieldSchema] : []
-            })
-          )
+        // 由于 ScenarioField.CustomField 数据终究是可选的，因此认为这个失败不是致命的
+        // 返回 empty 允许程序继续工作
+        return Observable.of([] as CustomFieldSchema[])
+      })
+    )
+
+  // 由于 ScenarioFieldConfig 推送数据里不包含 CustomField 变化，因此缺少 CustomField 数据，
+  // 但后端会保证推送 CustomFieldLink 变化，所以使用 CustomFieldLink 做为 CustomField 使用，
+  // 进而保证 scenarioField.customfield 准确性
+  const customFieldLink$ = sdk
+    .getLinkByCustomFieldId(customFieldId, { request: empty$ })
+    .changes()
+    .pipe(
+      map(([link]) => {
+        return link ? [linkToCustomField(link) as CustomFieldSchema] : []
+      })
+    )
+
+  return sdk
+    .getCustomField(customFieldId, {
+      request: customField$ || customFieldPadding$ || empty$
+    })
+    .changes()
+    .pipe(
+      switchMap(([customField]) => {
+        return customField ? Observable.of([customField]) : customFieldLink$
       }),
       map(([customField]) => {
         return customField ? customField : void 0

--- a/src/schemas/ScenarioField.ts
+++ b/src/schemas/ScenarioField.ts
@@ -25,7 +25,7 @@ export interface NoteScenarioFieldSchema extends ScenarioFieldSchema {
 
 export interface CustomScenarioFieldSchema extends ScenarioFieldSchema<CustomScenarioFieldType> {
   _customfieldId: CustomFieldId
-  customfield?: CustomFieldSchema
+  customfield?: CustomFieldSchema | null // 返回 null 表示该字段不存在已经被删了
 }
 
 export type TaskScenarioFieldSchema =

--- a/test/apis/scenariofieldconfig.spec.ts
+++ b/test/apis/scenariofieldconfig.spec.ts
@@ -819,4 +819,166 @@ describe('ScenarioFieldConfigApi spec: ', () => {
       expect(fetchMock.called(customFieldUrl)).to.be.true
     })
   })
+
+  it('should not fetch CustomField when using withCustomfields=true & CustomField=null (Project)', function*() {
+    const customFieldId = 'mock-cf-id' as CustomFieldId
+    const customField = { _id: customFieldId } as CustomFieldSchema
+
+    const configId = 'mock-sfc-id' as ScenarioFieldConfigId
+    const projectId = 'mock-project-id' as ProjectId
+    const objectType = 'task'
+    const config = {
+      _id: configId,
+      _boundToObjectId: projectId,
+      objectType,
+      scenariofields: [
+        {
+          fieldType: 'customfield',
+          _customfieldId: customFieldId,
+          customfield: null
+        } as CustomScenarioFieldSchema
+      ] as ScenarioFieldSchema[]
+    } as ScenarioFieldConfigSchema
+
+    fetchMock.getOnce('*', [config])
+
+    const customFieldUrl = `/customfields/${customFieldId}?_=666`
+    fetchMock.getOnce(customFieldUrl, customField)
+
+    yield sdk
+      .getScenarioFieldConfigs(projectId, objectType)
+      .take(1)
+      .subscribeOn(Scheduler.asap)
+      .do(([result]) => {
+        // 缺少 CustomField 数据
+        const resultScenarioField = result
+          .scenariofields[0] as CustomScenarioFieldSchema
+        expect(resultScenarioField.customfield).to.be.null
+
+        // 缺少 CustomField 数据，默认不会发送请求进行获取
+        expect(fetchMock.called(customFieldUrl)).to.be.false
+      })
+  })
+
+  it('should fetch CustomField when using withCustomfields=true & CustomField=undefined (Project)', function*() {
+    const customFieldId = 'mock-cf-id' as CustomFieldId
+    const customField = { _id: customFieldId } as CustomFieldSchema
+    const customScenarioField = {
+      fieldType: 'customfield',
+      _customfieldId: customFieldId
+    } as CustomScenarioFieldSchema
+
+    const configId = 'mock-sfc-id' as ScenarioFieldConfigId
+    const projectId = 'mock-project-id' as ProjectId
+    const objectType = 'task'
+    const config = {
+      _id: configId,
+      _boundToObjectId: projectId,
+      objectType,
+      scenariofields: [customScenarioField] as ScenarioFieldSchema[]
+    } as ScenarioFieldConfigSchema
+
+    fetchMock.getOnce('*', [config])
+
+    const customFieldUrl = `/customfields/${customFieldId}?_=666`
+    fetchMock.getOnce(customFieldUrl, customField)
+
+    yield sdk
+      .getScenarioFieldConfigs(projectId, objectType)
+      .take(1)
+      .subscribeOn(Scheduler.asap)
+      .do(([result]) => {
+        // 填补了 CustomField 数据
+        const resultScenarioField = result
+          .scenariofields[0] as CustomScenarioFieldSchema
+        expectToDeepEqualForFieldsOfTheExpected(
+          resultScenarioField.customfield,
+          customField
+        )
+
+        // 由于 CustomField=undefined 那么发送请求进行获取
+        expect(fetchMock.called(customFieldUrl)).to.be.true
+      })
+  })
+
+  it('should not fetch CustomField when using withCustomfields=true & CustomField=null (Organization)', function*() {
+    const customFieldId = 'mock-cf-id' as CustomFieldId
+    const customField = { _id: customFieldId } as CustomFieldSchema
+
+    const configId = 'mock-sfc-id' as ScenarioFieldConfigId
+    const orgId = 'mock-org-id' as OrganizationId
+    const objectType = 'task'
+    const config = {
+      _id: configId,
+      _boundToObjectId: orgId,
+      objectType,
+      scenariofields: [
+        {
+          fieldType: 'customfield',
+          _customfieldId: customFieldId,
+          customfield: null
+        } as CustomScenarioFieldSchema
+      ] as ScenarioFieldSchema[]
+    } as ScenarioFieldConfigSchema
+
+    fetchMock.getOnce('*', { result: [config] })
+
+    const customFieldUrl = `/customfields/${customFieldId}?_=666`
+    fetchMock.getOnce(customFieldUrl, customField)
+
+    yield sdk
+      .getOrgScenarioFieldConfigs(orgId, objectType)
+      .take(1)
+      .subscribeOn(Scheduler.asap)
+      .do(([result]) => {
+        // 缺少 CustomField 数据
+        const resultScenarioField = result
+          .scenariofields[0] as CustomScenarioFieldSchema
+        expect(resultScenarioField.customfield).to.be.null
+
+        // 缺少 CustomField 数据，默认不会发送请求进行获取
+        expect(fetchMock.called(customFieldUrl)).to.be.false
+      })
+  })
+
+  it('should fetch CustomField when using withCustomfields=true & CustomField=undefined (Organization)', function*() {
+    const customFieldId = 'mock-cf-id' as CustomFieldId
+    const customField = { _id: customFieldId } as CustomFieldSchema
+    const customScenarioField = {
+      fieldType: 'customfield',
+      _customfieldId: customFieldId
+    } as CustomScenarioFieldSchema
+
+    const configId = 'mock-sfc-id' as ScenarioFieldConfigId
+    const orgId = 'mock-org-id' as OrganizationId
+    const objectType = 'task'
+    const config = {
+      _id: configId,
+      _boundToObjectId: orgId,
+      objectType,
+      scenariofields: [customScenarioField] as ScenarioFieldSchema[]
+    } as ScenarioFieldConfigSchema
+
+    fetchMock.getOnce('*', { result: [config] })
+
+    const customFieldUrl = `/customfields/${customFieldId}?_=666`
+    fetchMock.getOnce(customFieldUrl, customField)
+
+    yield sdk
+      .getOrgScenarioFieldConfigs(orgId, objectType)
+      .take(1)
+      .subscribeOn(Scheduler.asap)
+      .do(([result]) => {
+        // 填补了 CustomField 数据
+        const resultScenarioField = result
+          .scenariofields[0] as CustomScenarioFieldSchema
+        expectToDeepEqualForFieldsOfTheExpected(
+          resultScenarioField.customfield,
+          customField
+        )
+
+        // 由于 CustomField=undefined 那么发送请求进行获取
+        expect(fetchMock.called(customFieldUrl)).to.be.true
+      })
+  })
 })


### PR DESCRIPTION
默认情况下(withCustomField=true)，请求 ScenarioFieldConfig 得到的
`scenariofields` 字段的元素里，带 `_customfieldId` 的元素会带有
`customfield` 数据，无需另外请求。

但存在 `_customfieldId` 对应的自定义字段被删的情况，这时后端原来返回的
`customfield` 字段会是 undefined。这导致前端无从判断当前是缺值还是空值，
结果发起不必要的自定义字段数据请求（在该自定义字段被删的情况下，后端会
报 404）。

后端新的实现，是在前端带有 `withCustomField=true` 来请求
scenariofieldconfig 数据时，对自定义字段被删的 scenariofield，用
`null` 填入 `customfield` 字段。前端做相应调整：当其值为 null，不发起
不必要的请求；当其值为 undefined，发起填补该数据的请求。

by @aicest , @chuan6 