### PR TITLE
feat(schemas/Task): 补充 `taskflowstatus` 字段

### DIFF
--- a/src/schemas/Task.ts
+++ b/src/schemas/Task.ts
@@ -18,6 +18,7 @@ import { ProjectSchema } from './Project'
 import { SprintSchema } from './Sprint'
 import { StageSchema } from './Stage'
 import { TagSchema } from './Tag'
+import { TaskflowStatusSnippet } from './TaskflowStatus'
 
 export interface TaskSchema {
   _id: TaskId
@@ -75,6 +76,7 @@ export interface TaskSchema {
   stage: Pick<StageSchema, '_id' | 'name' | 'order'>
   storyPoint: string
   sprint?: SprintSchema
+  taskflowstatus?: TaskflowStatusSnippet | null
   tasklist?: {
     _id: TasklistId
     title: string
@@ -288,6 +290,15 @@ const schema: SchemaDef<TaskSchema> = {
   },
   tags: {
     type: RDBType.OBJECT
+  },
+  taskflowstatus: {
+    type: Relationship.oneToOne,
+    virtual: {
+      name: 'TaskflowStatus',
+      where: (taskflowStatusTable: any) => ({
+        _taskflowstatusId: taskflowStatusTable._id
+      })
+    }
   },
   tasklist: {
     type: Relationship.oneToOne,


### PR DESCRIPTION
在这之前，后端已经在部分接口有返回该字段，比如获取单个任务接口。