### PR TITLE
feature:  将 GraphQL 相关类型定义从 index 中暴露出来

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,4 +26,6 @@ export { Net, CacheStrategy, Http, HttpErrorMessage, HttpError$, Page } from './
 
 export { Database, ExecutorResult, QueryToken, OrderDescription, Query, Predicate } from './db'
 
+export { GraphQLQuery, GraphQLMeta, GraphQLVariables, GraphQLResult } from './utils'
+
 // export const SocketClient: Client = sdk.socket


### PR DESCRIPTION
在外部需要对 sdk.graph 接口进行包装的时候需要用到这几个类型定义