### PR TITLE
fix(Net/persist): 纠正错误处理方式，拿掉 err 是 Observable 的假设

### DIFF
--- a/src/Net/Net.ts
+++ b/src/Net/Net.ts
@@ -305,9 +305,9 @@ export class Net {
     this.persistedDataBuffer.length = 0
 
     return Observable.from(asyncQueue).concatAll().do({
-      error: async (err: Observable<Error>) => {
-        const errObj = await err.toPromise()
-        SDKLogger.error(errObj.message)
+      error: (err) => {
+        const errmsg = err && err.message || String(err)
+        SDKLogger.error(errmsg)
       }
     })
   }


### PR DESCRIPTION
...err 是 Observable 的合理可能只存在于有地方抛错时抛的是 Observable
的情况；这不符合正常操作习惯。（已经在 #668 中由于导致测试失败提前调整）

- [ ] 确认当前 persist 方法里可能遇到的报错对象有哪些？
- [ ] 补充单元测试