### PR TITLE
refactor(ProjectSchema): 弱化 proTemplateType 和 normalType 类型

### DIFF
--- a/src/schemas/Project.ts
+++ b/src/schemas/Project.ts
@@ -97,8 +97,8 @@ export interface ProjectSchema {
   updated: string
   visibility: 'project' | 'organization' | 'all'
   worksCount: number
-  proTemplateType?: 'scrum'
-  normalType: 'taskflow' | null
+  proTemplateType?: string // 如 'scrum'
+  normalType: string /*如 'taskflow'*/ | null
   windowModeOfAddTask: 'large' | 'default'
 }
 


### PR DESCRIPTION
这两个字段的使用在敏捷项目和工作流项目普通化的过程中，它们的值更适合于
作为实现细节隐藏在工具函数里，不鼓励业务代码直接使用它们。