### PR TITLE
refactor(sockets/MapToTable): 弱化从复数自动匹配到单数表名逻辑的决定性

### DIFF
--- a/src/sockets/MapToTable.ts
+++ b/src/sockets/MapToTable.ts
@@ -25,15 +25,15 @@ export class TableInfoByMessageType {
   }
 
   private getTableName(msgType: string): string | undefined {
-    const msgtypes = msgType.toLowerCase()
+    const msgtype = msgType.toLowerCase()
 
-    const alias = this.tabAliasByLowerCase[msgtypes]
+    const alias = this.tabAliasByLowerCase[msgtype]
     if (alias) {
       return this.tableAlias[alias]
     }
 
-    const msgtype = cutTrailingS(msgtypes)
     return this.tabNameByLowerCase[msgtype]
+     || this.tabNameByLowerCase[cutTrailingS(msgtype)]
   }
 
   getTableInfo(msgType: string): TableInfo | null {

--- a/src/sockets/TableAlias.ts
+++ b/src/sockets/TableAlias.ts
@@ -15,7 +15,6 @@ export default {
   ChatMessages: 'Activity',
   Activities: 'Activity',
   HomeActivities: 'HomeActivity',
-  TaskflowStatus: 'TaskflowStatus', // 会被作为复数形式去除最后的s
   CustomFieldCategories: 'CustomFieldCategory',
   Dependency: 'TaskDependency',
   Dependencies: 'TaskDependency',

--- a/test/sockets/mapToTable.spec.ts
+++ b/test/sockets/mapToTable.spec.ts
@@ -14,7 +14,8 @@ describe('TableInfoByMessageType spec', () => {
     { name: 'Event', schema: { _id: { primaryKey: true } } },
     { name: 'Activity', schema: { _id: { primaryKey: true } } },
     { name: 'CustomFieldLink', schema: { _id: { primaryKey: true } } },
-    { name: 'Alias', schema: { _id: { primaryKey: true } } }
+    { name: 'Alias', schema: { _id: { primaryKey: true } } },
+    { name: 'TaskFlowStatus', schema: { _id: { primaryKey: true } } }
   ]
 
   schemas.forEach((schemaInfo: any) => {
@@ -44,6 +45,12 @@ describe('TableInfoByMessageType spec', () => {
     const target = { pkName: '_id', tabName: 'Event' }
     expect(mapToTable.getTableInfo('events')).to.deep.equal(target)
     expect(mapToTable.getTableInfo('Events')).to.deep.equal(target)
+  })
+
+  it('should map a singular form message `ssss` or `SsSs` to its table info', () => {
+    const target = { pkName: '_id', tabName: 'TaskFlowStatus' }
+    expect(mapToTable.getTableInfo('taskflowstatus')).to.deep.equal(target)
+    expect(mapToTable.getTableInfo('TaskFlowStatus')).to.deep.equal(target)
   })
 
   it('should return null when no table info is defined for the message `type-ies`', () => {


### PR DESCRIPTION
从 websocket 事件上可能单复数形式共存的对象名称到唯一确定的表名（一般
是单数形式）的转换，是通过一个简单的 cutSTrailing 函数做到的，它无差别
地把结尾的 `s` 给拿掉，没有任何智能的逻辑，也对当前词汇无感。

将这个转换得到的结果与表名匹配，原先是 alias 匹配之后唯一的匹配逻辑。
导致一些以 `s` 结尾的对象名（如：`taskflowstatus`）被误砍 `s`，结果
（如：`taskflowstatu`）与表名不能匹配，导致需要特别定义 alias 条目来绕
开，让后期新增对象名的过程多了一个可能的坑。

这里调整为，在 alias 匹配之后，优先做直接匹配，只有当直接匹配失败，才
尝试砍掉 `s` 匹配单数。让这个不智能的单复数转换逻辑成为直接匹配的补充，
而不是替换。